### PR TITLE
Workaround for dapptools chain block zero

### DIFF
--- a/packages/ipld-eth-client/src/eth-client.ts
+++ b/packages/ipld-eth-client/src/eth-client.ts
@@ -83,9 +83,7 @@ export class EthClient {
       block: {
         number: blockNumHex,
         timestamp: timestampHex,
-        parent: {
-          hash: parentHash
-        }
+        parent
       }
     } = result;
 
@@ -93,9 +91,7 @@ export class EthClient {
       hash: vars.blockHash,
       number: parseInt(blockNumHex, 16),
       timestamp: parseInt(timestampHex, 16),
-      parent: {
-        hash: parentHash
-      }
+      parent
     };
 
     const logs = resultLogs.map((logEntry: any) => _.merge({}, logEntry, { transaction: { block } }));

--- a/packages/uni-info-watcher/src/entity/BlockProgress.ts
+++ b/packages/uni-info-watcher/src/entity/BlockProgress.ts
@@ -17,7 +17,7 @@ export class BlockProgress implements BlockProgressInterface {
   @Column('varchar', { length: 66 })
   blockHash!: string;
 
-  @Column('varchar', { length: 66 })
+  @Column('varchar', { length: 66, nullable: true })
   parentHash!: string;
 
   @Column('integer')

--- a/packages/uni-watcher/src/entity/BlockProgress.ts
+++ b/packages/uni-watcher/src/entity/BlockProgress.ts
@@ -17,7 +17,7 @@ export class BlockProgress implements BlockProgressInterface {
   @Column('varchar', { length: 66 })
   blockHash!: string;
 
-  @Column('varchar', { length: 66 })
+  @Column('varchar', { length: 66, nullable: true })
   parentHash!: string;
 
   @Column('integer')

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -474,7 +474,7 @@ export class Indexer implements IndexerInterface {
         blockHash,
         blockNumber: block.number,
         blockTimestamp: block.timestamp,
-        parentHash: block.parent.hash
+        parentHash: block.parent?.hash
       };
 
       await this._db.saveEvents(dbTx, block, dbEvents);

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -197,9 +197,10 @@ export class Database {
     } = block;
 
     assert(blockHash);
-    assert(blockNumber);
-    assert(blockTimestamp);
-    assert(parentHash);
+    assert(blockNumber !== undefined);
+    assert(blockNumber > -1);
+    assert(blockTimestamp !== undefined);
+    assert(blockTimestamp > -1);
 
     // In a transaction:
     // (1) Save all the events in the database.

--- a/packages/util/src/fill.ts
+++ b/packages/util/src/fill.ts
@@ -35,6 +35,12 @@ export const fillBlocks = async (
       if (blockProgress) {
         log(`Block number ${blockNumber}, block hash ${blockHash} already known, skip filling`);
       } else {
+        const syncStatus = await indexer.getSyncStatus();
+
+        if (!syncStatus || syncStatus.chainHeadBlockNumber < blockNumber) {
+          await indexer.updateSyncStatusChainHead(blockHash, blockNumber);
+        }
+
         await jobQueue.pushJob(QUEUE_BLOCK_PROCESSING, { kind: JOB_KIND_INDEX, blockHash, blockNumber, parentHash, timestamp });
       }
     }

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -139,7 +139,7 @@ export class JobRunner {
       const parent = await this._indexer.getBlockProgress(parentHash);
 
       if (!parent) {
-        const { number: parentBlockNumber, parent: { hash: grandparentHash }, timestamp: parentTimestamp } = await this._indexer.getBlock(parentHash);
+        const { number: parentBlockNumber, parent: grandparent, timestamp: parentTimestamp } = await this._indexer.getBlock(parentHash);
 
         // Create a higher priority job to index parent block and then abort.
         // We don't have to worry about aborting as this job will get retried later.
@@ -148,7 +148,7 @@ export class JobRunner {
           kind: JOB_KIND_INDEX,
           blockHash: parentHash,
           blockNumber: parentBlockNumber,
-          parentHash: grandparentHash,
+          parentHash: grandparent?.hash,
           timestamp: parentTimestamp,
           priority: newPriority
         }, { priority: newPriority });


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/45.

The dapp tools chain returns block number 0 on start. This change works around that. On geth, the first block is numbered 1.