### PR TITLE
Get endpoint URL from config in tests

### DIFF
--- a/packages/uni-info-watcher/environments/local.toml
+++ b/packages/uni-info-watcher/environments/local.toml
@@ -19,6 +19,7 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8545"
 
   [upstream.cache]
     name = "requests"

--- a/packages/uni-info-watcher/src/smoke.test.ts
+++ b/packages/uni-info-watcher/src/smoke.test.ts
@@ -43,7 +43,6 @@ import {
 } from '../test/utils';
 
 const CONFIG_FILE = './environments/local.toml';
-const NETWORK_RPC_URL = 'http://localhost:8545';
 
 describe('uni-info-watcher', () => {
   let factory: Contract;
@@ -64,16 +63,12 @@ describe('uni-info-watcher', () => {
   let client: Client;
 
   before(async () => {
-    const provider = new ethers.providers.JsonRpcProvider(NETWORK_RPC_URL);
-    signer = provider.getSigner();
-    recipient = await signer.getAddress();
-
     config = await getConfig(CONFIG_FILE);
 
     const { upstream, server: { host, port } } = config;
     const endpoint = `http://${host}:${port}/graphql`;
 
-    let { uniWatcher: { gqlEndpoint, gqlSubscriptionEndpoint } } = upstream;
+    let { uniWatcher: { gqlEndpoint, gqlSubscriptionEndpoint }, ethServer: { rpcProviderEndpoint } } = upstream;
     uniClient = new UniClient({
       gqlEndpoint,
       gqlSubscriptionEndpoint
@@ -85,6 +80,10 @@ describe('uni-info-watcher', () => {
       gqlEndpoint,
       gqlSubscriptionEndpoint
     });
+
+    const provider = new ethers.providers.JsonRpcProvider(rpcProviderEndpoint);
+    signer = provider.getSigner();
+    recipient = await signer.getAddress();
   });
 
   it('should have a Factory entity', async () => {

--- a/packages/uni-watcher/environments/local.toml
+++ b/packages/uni-watcher/environments/local.toml
@@ -16,6 +16,7 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
+    rpcProviderEndpoint = "http://127.0.0.1:8545"
 
   [upstream.cache]
     name = "requests"

--- a/packages/uni-watcher/src/smoke.test.ts
+++ b/packages/uni-watcher/src/smoke.test.ts
@@ -45,7 +45,6 @@ import {
 } from '../test/utils';
 
 const CONFIG_FILE = './environments/local.toml';
-const NETWORK_RPC_URL = 'http://localhost:8545';
 
 describe('uni-watcher', () => {
   let factory: Contract;
@@ -77,9 +76,10 @@ describe('uni-watcher', () => {
     assert(host, 'Missing host.');
     assert(port, 'Missing port.');
 
-    const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint }, cache: cacheConfig } = upstream;
+    const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
     assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint.');
     assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint.');
+    assert(rpcProviderEndpoint, 'Missing upstream ethServer.rpcProviderEndpoint.');
     assert(cacheConfig, 'Missing dbConfig.');
 
     db = new Database(dbConfig);
@@ -105,7 +105,7 @@ describe('uni-watcher', () => {
       gqlSubscriptionEndpoint
     });
 
-    const provider = new ethers.providers.JsonRpcProvider(NETWORK_RPC_URL);
+    const provider = new ethers.providers.JsonRpcProvider(rpcProviderEndpoint);
     signer = provider.getSigner();
     recipient = await signer.getAddress();
   });

--- a/packages/uni-watcher/test/init.ts
+++ b/packages/uni-watcher/test/init.ts
@@ -22,7 +22,6 @@ import { Database } from '../src/database';
 import { watchContract } from '../src/utils/index';
 
 const CONFIG_FILE = './environments/local.toml';
-const NETWORK_RPC_URL = 'http://localhost:8545';
 
 const deployFactoryContract = async (db: Database, signer: Signer): Promise<Contract> => {
   // Deploy factory from uniswap package.
@@ -53,10 +52,11 @@ const main = async () => {
   // Get config.
   const config = await getConfig(CONFIG_FILE);
 
-  const { database: dbConfig, server: { host, port } } = config;
+  const { database: dbConfig, server: { host, port }, upstream: { ethServer: { rpcProviderEndpoint } } } = config;
   assert(dbConfig, 'Missing dbConfig.');
   assert(host, 'Missing host.');
   assert(port, 'Missing port.');
+  assert(rpcProviderEndpoint, 'Missing rpcProviderEndpoint.');
 
   // Initialize uniClient.
   const endpoint = `http://${host}:${port}/graphql`;
@@ -71,7 +71,7 @@ const main = async () => {
   const db = new Database(dbConfig);
   await db.init();
 
-  const provider = new ethers.providers.JsonRpcProvider(NETWORK_RPC_URL);
+  const provider = new ethers.providers.JsonRpcProvider(rpcProviderEndpoint);
   const signer = provider.getSigner();
 
   let factory: Contract;


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/261

* Use endpoint URLs in testing from config to run successfully in docker demo https://github.com/vulcanize/uniswap-v3-info-watcher/pull/1