### PR TITLE
Increase sleep in smoke test to process events

### DIFF
--- a/packages/uni-info-watcher/src/smoke.test.ts
+++ b/packages/uni-info-watcher/src/smoke.test.ts
@@ -862,8 +862,8 @@ describe('uni-info-watcher', () => {
       eventType = 'IncreaseLiquidityEvent';
       eventValue = await watchEvent(uniClient, eventType);
 
-      // Sleeping for 10 sec for the events to be processed.
-      await wait(10000);
+      // Sleeping for 15 sec for the events to be processed.
+      await wait(15000);
     });
 
     it('should create a Transaction entity', async () => {
@@ -936,8 +936,8 @@ describe('uni-info-watcher', () => {
       eventType = 'DecreaseLiquidityEvent';
       eventValue = await watchEvent(uniClient, eventType);
 
-      // Sleeping for 10 sec for the events to be processed.
-      await wait(10000);
+      // Sleeping for 15 sec for the events to be processed.
+      await wait(15000);
     });
 
     it('should create a Transaction entity', async () => {


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/261

* Increase sleep time to avoid failing IncreaseLiquidity test