### PR TITLE
Process events in single job and avoid block progress query to improve performance

### DIFF
--- a/packages/erc20-watcher/environments/local.toml
+++ b/packages/erc20-watcher/environments/local.toml
@@ -30,3 +30,4 @@
   dbConnectionString = "postgres://postgres:postgres@localhost/erc20-watcher-job-queue"
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 100
+  eventsInBatch = 50

--- a/packages/erc20-watcher/src/database.ts
+++ b/packages/erc20-watcher/src/database.ts
@@ -101,10 +101,10 @@ export class Database {
     return this._baseDatabase.saveEventEntity(repo, entity);
   }
 
-  async getBlockEvents (blockHash: string, where: FindConditions<Event>): Promise<Event[]> {
+  async getBlockEvents (blockHash: string, options: FindManyOptions<Event>): Promise<Event[]> {
     const repo = this._conn.getRepository(Event);
 
-    return this._baseDatabase.getBlockEvents(repo, blockHash, where);
+    return this._baseDatabase.getBlockEvents(repo, blockHash, options);
   }
 
   async saveEvents (queryRunner: QueryRunner, block: DeepPartial<BlockProgress>, events: DeepPartial<Event>[]): Promise<void> {

--- a/packages/erc20-watcher/src/database.ts
+++ b/packages/erc20-watcher/src/database.ts
@@ -167,7 +167,7 @@ export class Database {
     return this._baseDatabase.getBlockProgress(repo, blockHash);
   }
 
-  async updateBlockProgress (queryRunner: QueryRunner, block: BlockProgress, lastProcessedEventIndex: number): Promise<void> {
+  async updateBlockProgress (queryRunner: QueryRunner, block: BlockProgress, lastProcessedEventIndex: number): Promise<BlockProgress> {
     const repo = queryRunner.manager.getRepository(BlockProgress);
 
     return this._baseDatabase.updateBlockProgress(repo, block, lastProcessedEventIndex);

--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -5,7 +5,7 @@
 import assert from 'assert';
 import debug from 'debug';
 import { JsonFragment } from '@ethersproject/abi';
-import { DeepPartial } from 'typeorm';
+import { DeepPartial, FindManyOptions } from 'typeorm';
 import JSONbig from 'json-bigint';
 import { ethers } from 'ethers';
 import { BaseProvider } from '@ethersproject/providers';
@@ -352,8 +352,8 @@ export class Indexer {
     return this._baseIndexer.getOrFetchBlockEvents(block, this._fetchAndSaveEvents.bind(this));
   }
 
-  async getBlockEvents (blockHash: string): Promise<Array<Event>> {
-    return this._baseIndexer.getBlockEvents(blockHash);
+  async getBlockEvents (blockHash: string, options: FindManyOptions<Event>): Promise<Array<Event>> {
+    return this._baseIndexer.getBlockEvents(blockHash, options);
   }
 
   async removeUnknownEvents (block: BlockProgress): Promise<void> {

--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -364,7 +364,7 @@ export class Indexer {
     return this._baseIndexer.markBlocksAsPruned(blocks);
   }
 
-  async updateBlockProgress (block: BlockProgress, lastProcessedEventIndex: number): Promise<void> {
+  async updateBlockProgress (block: BlockProgress, lastProcessedEventIndex: number): Promise<BlockProgress> {
     return this._baseIndexer.updateBlockProgress(block, lastProcessedEventIndex);
   }
 

--- a/packages/erc20-watcher/src/job-runner.ts
+++ b/packages/erc20-watcher/src/job-runner.ts
@@ -47,26 +47,12 @@ export class JobRunner {
   async subscribeBlockProcessingQueue (): Promise<void> {
     await this._jobQueue.subscribe(QUEUE_BLOCK_PROCESSING, async (job) => {
       await this._baseJobRunner.processBlock(job);
-
-      await this._jobQueue.markComplete(job);
     });
   }
 
   async subscribeEventProcessingQueue (): Promise<void> {
     await this._jobQueue.subscribe(QUEUE_EVENT_PROCESSING, async (job) => {
-      const event = await this._baseJobRunner.processEvent(job);
-
-      if (!event) {
-        return;
-      }
-
-      const watchedContract = await this._indexer.isWatchedContract(event.contract);
-      if (watchedContract) {
-        await this._indexer.processEvent(event);
-      }
-
-      await this._indexer.updateBlockProgress(event.block, event.index);
-      await this._jobQueue.markComplete(job);
+      await this._baseJobRunner.processEvent(job);
     });
   }
 }

--- a/packages/uni-info-watcher/environments/local.toml
+++ b/packages/uni-info-watcher/environments/local.toml
@@ -39,3 +39,4 @@
   dbConnectionString = "postgres://postgres:postgres@localhost/uni-info-watcher-job-queue"
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 1000
+  eventsInBatch = 50

--- a/packages/uni-info-watcher/environments/test.toml
+++ b/packages/uni-info-watcher/environments/test.toml
@@ -39,3 +39,4 @@
   dbConnectionString = "postgres://postgres:postgres@localhost/uni-info-watcher-job-queue"
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 1000
+  eventsInBatch = 50

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -663,7 +663,7 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.getBlockProgress(repo, blockHash);
   }
 
-  async updateBlockProgress (queryRunner: QueryRunner, block: BlockProgress, lastProcessedEventIndex: number): Promise<void> {
+  async updateBlockProgress (queryRunner: QueryRunner, block: BlockProgress, lastProcessedEventIndex: number): Promise<BlockProgress> {
     const repo = queryRunner.manager.getRepository(BlockProgress);
 
     return this._baseDatabase.updateBlockProgress(repo, block, lastProcessedEventIndex);

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -603,10 +603,10 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.saveEventEntity(repo, entity);
   }
 
-  async getBlockEvents (blockHash: string, where: FindConditions<Event>): Promise<Event[]> {
+  async getBlockEvents (blockHash: string, options?: FindManyOptions<Event>): Promise<Event[]> {
     const repo = this._conn.getRepository(Event);
 
-    return this._baseDatabase.getBlockEvents(repo, blockHash, where);
+    return this._baseDatabase.getBlockEvents(repo, blockHash, options);
   }
 
   async saveEvents (queryRunner: QueryRunner, block: DeepPartial<BlockProgress>, events: DeepPartial<Event>[]): Promise<void> {

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -197,6 +197,10 @@ export class Indexer implements IndexerInterface {
     };
   }
 
+  async saveEventEntity (dbEvent: Event): Promise<Event> {
+    return this._baseIndexer.saveEventEntity(dbEvent);
+  }
+
   async markBlocksAsPruned (blocks: BlockProgress[]): Promise<void> {
     return this._baseIndexer.markBlocksAsPruned(blocks);
   }
@@ -346,7 +350,7 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.getBlocksAtHeight(height, isPruned);
   }
 
-  async updateBlockProgress (block: BlockProgress, lastProcessedEventIndex: number): Promise<void> {
+  async updateBlockProgress (block: BlockProgress, lastProcessedEventIndex: number): Promise<BlockProgress> {
     return this._baseIndexer.updateBlockProgress(block, lastProcessedEventIndex);
   }
 

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -4,7 +4,7 @@
 
 import assert from 'assert';
 import debug from 'debug';
-import { DeepPartial, QueryRunner } from 'typeorm';
+import { DeepPartial, FindManyOptions, QueryRunner } from 'typeorm';
 import JSONbig from 'json-bigint';
 import { providers, utils, BigNumber } from 'ethers';
 
@@ -310,8 +310,8 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.getOrFetchBlockEvents(block, this._fetchAndSaveEvents.bind(this));
   }
 
-  async getBlockEvents (blockHash: string): Promise<Array<Event>> {
-    return this._baseIndexer.getBlockEvents(blockHash);
+  async getBlockEvents (blockHash: string, options: FindManyOptions<Event>): Promise<Array<Event>> {
+    return this._baseIndexer.getBlockEvents(blockHash, options);
   }
 
   async removeUnknownEvents (block: BlockProgress): Promise<void> {

--- a/packages/uni-info-watcher/src/job-runner.ts
+++ b/packages/uni-info-watcher/src/job-runner.ts
@@ -49,26 +49,12 @@ export class JobRunner {
   async subscribeBlockProcessingQueue (): Promise<void> {
     await this._jobQueue.subscribe(QUEUE_BLOCK_PROCESSING, async (job) => {
       await this._baseJobRunner.processBlock(job);
-
-      await this._jobQueue.markComplete(job);
     });
   }
 
   async subscribeEventProcessingQueue (): Promise<void> {
     await this._jobQueue.subscribe(QUEUE_EVENT_PROCESSING, async (job) => {
-      const event = await this._baseJobRunner.processEvent(job);
-
-      if (!event) {
-        return;
-      }
-
-      // Check if event is processed.
-      if (!event.block.isComplete && event.index !== event.block.lastProcessedEventIndex) {
-        await this._indexer.processEvent(event);
-      }
-
-      await this._indexer.updateBlockProgress(event.block, event.index);
-      await this._jobQueue.markComplete(job);
+      await this._baseJobRunner.processEvent(job);
     });
   }
 }

--- a/packages/uni-info-watcher/src/smoke.test.ts
+++ b/packages/uni-info-watcher/src/smoke.test.ts
@@ -768,19 +768,15 @@ describe('uni-info-watcher', () => {
         fee
       });
 
-      eventType = 'MintEvent';
-      await Promise.all([
-        transaction,
-        watchEvent(uniClient, eventType)
+      [eventValue] = await Promise.all([
+        // Wait for TransferEvent and get eventValue.
+        watchEvent(uniClient, 'TransferEvent'),
+        // Wait for MintEvent.
+        watchEvent(uniClient, 'MintEvent'),
+        // Wait for IncreaseLiquidityEvent.
+        watchEvent(uniClient, 'IncreaseLiquidityEvent'),
+        transaction
       ]);
-
-      // Wait for TransferEvent.
-      eventType = 'TransferEvent';
-      eventValue = await watchEvent(uniClient, eventType);
-
-      // Wait for IncreaseLiquidityEvent.
-      eventType = 'IncreaseLiquidityEvent';
-      await watchEvent(uniClient, eventType);
 
       // Sleeping for 15 sec for the events to be processed.
       await wait(15000);
@@ -831,7 +827,6 @@ describe('uni-info-watcher', () => {
 
     let oldPosition: any;
     let eventValue: any;
-    let eventType: string;
 
     const tokenId = 1;
     const amount0Desired = 15;
@@ -856,15 +851,13 @@ describe('uni-info-watcher', () => {
         deadline
       });
 
-      eventType = 'MintEvent';
-      await Promise.all([
-        transaction,
-        watchEvent(uniClient, eventType)
+      [eventValue] = await Promise.all([
+        // Wait for IncreaseLiquidityEvent and get eventValue.
+        watchEvent(uniClient, 'IncreaseLiquidityEvent'),
+        // Wait for MintEvent.
+        watchEvent(uniClient, 'MintEvent'),
+        transaction
       ]);
-
-      // Wait for IncreaseLiquidityEvent.
-      eventType = 'IncreaseLiquidityEvent';
-      eventValue = await watchEvent(uniClient, eventType);
 
       // Sleeping for 15 sec for the events to be processed.
       await wait(15000);
@@ -906,7 +899,6 @@ describe('uni-info-watcher', () => {
 
     let oldPosition: any;
     let eventValue: any;
-    let eventType: string;
 
     const tokenId = 1;
     const liquidity = 5;
@@ -929,15 +921,13 @@ describe('uni-info-watcher', () => {
         deadline
       });
 
-      eventType = 'BurnEvent';
-      await Promise.all([
-        transaction,
-        watchEvent(uniClient, eventType)
+      [eventValue] = await Promise.all([
+        // Wait for DecreaseLiquidityEvent and get eventValue.
+        watchEvent(uniClient, 'DecreaseLiquidityEvent'),
+        // Wait for BurnEvent
+        watchEvent(uniClient, 'BurnEvent'),
+        transaction
       ]);
-
-      // Wait for DecreaseLiquidityEvent.
-      eventType = 'DecreaseLiquidityEvent';
-      eventValue = await watchEvent(uniClient, eventType);
 
       // Sleeping for 15 sec for the events to be processed.
       await wait(15000);
@@ -978,8 +968,6 @@ describe('uni-info-watcher', () => {
     // Checked entities: Transaction.
     // Unchecked entities: Position.
 
-    let eventType: string;
-
     const tokenId = 1;
     const amount0Max = 15;
     const amount1Max = 15;
@@ -993,15 +981,13 @@ describe('uni-info-watcher', () => {
         amount1Max
       });
 
-      eventType = 'BurnEvent';
       await Promise.all([
         transaction,
-        watchEvent(uniClient, eventType)
+        // Wait for BurnEvent.
+        watchEvent(uniClient, 'BurnEvent'),
+        // Wait for CollectEvent.
+        watchEvent(uniClient, 'CollectEvent')
       ]);
-
-      // Wait for CollectEvent.
-      eventType = 'CollectEvent';
-      await watchEvent(uniClient, eventType);
 
       // Sleeping for 10 sec for the events to be processed.
       await wait(10000);

--- a/packages/uni-watcher/environments/local.toml
+++ b/packages/uni-watcher/environments/local.toml
@@ -28,3 +28,4 @@
   dbConnectionString = "postgres://postgres:postgres@localhost/uni-watcher-job-queue"
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 100
+  eventsInBatch = 50

--- a/packages/uni-watcher/environments/test.toml
+++ b/packages/uni-watcher/environments/test.toml
@@ -28,3 +28,4 @@
   dbConnectionString = "postgres://postgres:postgres@localhost/uni-watcher-job-queue"
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 100
+  eventsInBatch = 50

--- a/packages/uni-watcher/src/database.ts
+++ b/packages/uni-watcher/src/database.ts
@@ -138,7 +138,7 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.getBlockProgress(repo, blockHash);
   }
 
-  async updateBlockProgress (queryRunner: QueryRunner, block: BlockProgress, lastProcessedEventIndex: number): Promise<void> {
+  async updateBlockProgress (queryRunner: QueryRunner, block: BlockProgress, lastProcessedEventIndex: number): Promise<BlockProgress> {
     const repo = queryRunner.manager.getRepository(BlockProgress);
 
     return this._baseDatabase.updateBlockProgress(repo, block, lastProcessedEventIndex);

--- a/packages/uni-watcher/src/database.ts
+++ b/packages/uni-watcher/src/database.ts
@@ -78,10 +78,10 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.saveEventEntity(repo, entity);
   }
 
-  async getBlockEvents (blockHash: string, where: FindConditions<Event>): Promise<Event[]> {
+  async getBlockEvents (blockHash: string, options: FindManyOptions<Event>): Promise<Event[]> {
     const repo = this._conn.getRepository(Event);
 
-    return this._baseDatabase.getBlockEvents(repo, blockHash, where);
+    return this._baseDatabase.getBlockEvents(repo, blockHash, options);
   }
 
   async saveEvents (queryRunner: QueryRunner, block: DeepPartial<BlockProgress>, events: DeepPartial<Event>[]): Promise<void> {

--- a/packages/uni-watcher/src/events.ts
+++ b/packages/uni-watcher/src/events.ts
@@ -81,16 +81,22 @@ export class EventWatcher implements EventWatcherInterface {
         return;
       }
 
-      const dbEvent = await this._baseEventWatcher.eventProcessingCompleteHandler(job);
-
+      const dbEvents = await this._baseEventWatcher.eventProcessingCompleteHandler(job);
       const timeElapsedInSeconds = (Date.now() - Date.parse(createdOn)) / 1000;
-      log(`Job onComplete event ${request.data.id} publish ${!!request.data.publish}`);
-      if (!failed && state === 'completed' && request.data.publish) {
-        // Check for max acceptable lag time between request and sending results to live subscribers.
-        if (timeElapsedInSeconds <= this._jobQueue.maxCompletionLag) {
-          await this.publishUniswapEventToSubscribers(dbEvent, timeElapsedInSeconds);
-        } else {
-          log(`event ${request.data.id} is too old (${timeElapsedInSeconds}s), not broadcasting to live subscribers`);
+
+      // Cannot publish individual event as they are processed together in a single job.
+      // TODO: Use a different pubsub to publish event from job-runner.
+      // https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries
+      for (const dbEvent of dbEvents) {
+        log(`Job onComplete event ${dbEvent.id} publish ${!!request.data.publish}`);
+
+        if (!failed && state === 'completed' && request.data.publish) {
+          // Check for max acceptable lag time between request and sending results to live subscribers.
+          if (timeElapsedInSeconds <= this._jobQueue.maxCompletionLag) {
+            await this.publishUniswapEventToSubscribers(dbEvent, timeElapsedInSeconds);
+          } else {
+            log(`event ${dbEvent.id} is too old (${timeElapsedInSeconds}s), not broadcasting to live subscribers`);
+          }
         }
       }
     });

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -3,7 +3,7 @@
 //
 
 import debug from 'debug';
-import { DeepPartial, QueryRunner } from 'typeorm';
+import { DeepPartial, FindManyOptions, QueryRunner } from 'typeorm';
 import JSONbig from 'json-bigint';
 import { ethers } from 'ethers';
 import assert from 'assert';
@@ -372,8 +372,8 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.getOrFetchBlockEvents(block, this._fetchAndSaveEvents.bind(this));
   }
 
-  async getBlockEvents (blockHash: string): Promise<Array<Event>> {
-    return this._baseIndexer.getBlockEvents(blockHash);
+  async getBlockEvents (blockHash: string, options: FindManyOptions<Event>): Promise<Array<Event>> {
+    return this._baseIndexer.getBlockEvents(blockHash, options);
   }
 
   async removeUnknownEvents (block: BlockProgress): Promise<void> {

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -416,7 +416,7 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.markBlocksAsPruned(blocks);
   }
 
-  async updateBlockProgress (block: BlockProgress, lastProcessedEventIndex: number): Promise<void> {
+  async updateBlockProgress (block: BlockProgress, lastProcessedEventIndex: number): Promise<BlockProgress> {
     return this._baseIndexer.updateBlockProgress(block, lastProcessedEventIndex);
   }
 

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -21,6 +21,7 @@ export interface JobQueueConfig {
   dbConnectionString: string;
   maxCompletionLagInSecs: number;
   jobDelayInMilliSecs?: number;
+  eventsInBatch: number;
 }
 
 interface ServerConfig {

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -11,7 +11,6 @@ export const QUEUE_CHAIN_PRUNING = 'chain-pruning';
 export const JOB_KIND_INDEX = 'index';
 export const JOB_KIND_PRUNE = 'prune';
 
-export const JOB_KIND_EVENTS = 'events';
 export const JOB_KIND_EVENT = 'event';
 export const JOB_KIND_CONTRACT = 'contract';
 

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -11,8 +11,9 @@ export const QUEUE_CHAIN_PRUNING = 'chain-pruning';
 export const JOB_KIND_INDEX = 'index';
 export const JOB_KIND_PRUNE = 'prune';
 
-export const JOB_KIND_CONTRACT = 'contract';
+export const JOB_KIND_EVENTS = 'events';
 export const JOB_KIND_EVENT = 'event';
+export const JOB_KIND_CONTRACT = 'contract';
 
 export const DEFAULT_CONFIG_PATH = 'environments/local.toml';
 

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -11,7 +11,7 @@ export const QUEUE_CHAIN_PRUNING = 'chain-pruning';
 export const JOB_KIND_INDEX = 'index';
 export const JOB_KIND_PRUNE = 'prune';
 
-export const JOB_KIND_EVENT = 'event';
+export const JOB_KIND_EVENTS = 'events';
 export const JOB_KIND_CONTRACT = 'contract';
 
 export const DEFAULT_CONFIG_PATH = 'environments/local.toml';

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -189,19 +189,26 @@ export class Database {
     return repo.findOne(id, { relations: ['block'] });
   }
 
-  async getBlockEvents (repo: Repository<EventInterface>, blockHash: string, where: FindConditions<EventInterface> = {}): Promise<EventInterface[]> {
-    where.block = {
-      ...where.block,
-      blockHash
+  async getBlockEvents (repo: Repository<EventInterface>, blockHash: string, options: FindManyOptions<EventInterface> = {}): Promise<EventInterface[]> {
+    if (!Array.isArray(options.where)) {
+      options.where = [options.where || {}];
+    }
+
+    options.where.forEach((where: FindConditions<EventInterface> = {}) => {
+      where.block = {
+        ...where.block,
+        blockHash
+      };
+    });
+
+    options.relations = ['block'];
+
+    options.order = {
+      ...options.order,
+      id: 'ASC'
     };
 
-    return repo.find({
-      where,
-      relations: ['block'],
-      order: {
-        id: 'ASC'
-      }
-    });
+    return repo.find(options);
   }
 
   async saveEvents (blockRepo: Repository<BlockProgressInterface>, eventRepo: Repository<EventInterface>, block: DeepPartial<BlockProgressInterface>, events: DeepPartial<EventInterface>[]): Promise<void> {

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -153,7 +153,7 @@ export class Database {
       .getMany();
   }
 
-  async updateBlockProgress (repo: Repository<BlockProgressInterface>, block: BlockProgressInterface, lastProcessedEventIndex: number): Promise<void> {
+  async updateBlockProgress (repo: Repository<BlockProgressInterface>, block: BlockProgressInterface, lastProcessedEventIndex: number): Promise<BlockProgressInterface> {
     if (!block.isComplete) {
       if (lastProcessedEventIndex <= block.lastProcessedEventIndex) {
         throw new Error(`Events processed out of order ${block.blockHash}, was ${block.lastProcessedEventIndex}, got ${lastProcessedEventIndex}`);
@@ -165,9 +165,18 @@ export class Database {
         block.isComplete = true;
       }
 
-      const { id, ...blockData } = block;
-      await repo.update(id, blockData);
+      const { generatedMaps } = await repo.createQueryBuilder()
+        .update(block)
+        .set(block)
+        .where('id = :id', { id: block.id })
+        .whereEntity(block)
+        .returning('*')
+        .execute();
+
+      block = generatedMaps[0] as BlockProgressInterface;
     }
+
+    return block;
   }
 
   async markBlocksAsPruned (repo: Repository<BlockProgressInterface>, blocks: BlockProgressInterface[]): Promise<void> {

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -100,12 +100,10 @@ export class EventWatcher {
   }
 
   async eventProcessingCompleteHandler (job: any): Promise<EventInterface> {
-    const { data: { request } } = job;
+    const { data: { request: { data: { event } } } } = job;
+    assert(event);
 
-    const dbEvent = await this._indexer.getEvent(request.data.id);
-    assert(dbEvent);
-
-    const blockProgress = await this._indexer.getBlockProgress(dbEvent.block.blockHash);
+    const blockProgress = await this._indexer.getBlockProgress(event.block.blockHash);
 
     if (blockProgress) {
       await this.publishBlockProgressToSubscribers(blockProgress);
@@ -115,7 +113,7 @@ export class EventWatcher {
       }
     }
 
-    return dbEvent;
+    return event;
   }
 
   async publishBlockProgressToSubscribers (blockProgress: BlockProgressInterface): Promise<void> {

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -5,12 +5,13 @@
 import assert from 'assert';
 import debug from 'debug';
 import { PubSub } from 'apollo-server-express';
+import { Not } from 'typeorm';
 
 import { EthClient } from '@vulcanize/ipld-eth-client';
 
 import { JobQueue } from './job-queue';
 import { BlockProgressInterface, EventInterface, IndexerInterface } from './types';
-import { MAX_REORG_DEPTH, JOB_KIND_PRUNE, JOB_KIND_INDEX } from './constants';
+import { MAX_REORG_DEPTH, JOB_KIND_PRUNE, JOB_KIND_INDEX, UNKNOWN_EVENT_NAME } from './constants';
 import { createPruningJob, processBlockByNumber } from './common';
 import { UpstreamConfig } from './config';
 
@@ -115,6 +116,9 @@ export class EventWatcher {
     return this._indexer.getBlockEvents(
       blockProgress.blockHash,
       {
+        where: {
+          eventName: Not(UNKNOWN_EVENT_NAME)
+        },
         order: {
           index: 'ASC'
         }

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -169,21 +169,20 @@ export class Indexer {
     }
   }
 
-  async updateBlockProgress (block: BlockProgressInterface, lastProcessedEventIndex: number): Promise<void> {
+  async updateBlockProgress (block: BlockProgressInterface, lastProcessedEventIndex: number): Promise<BlockProgressInterface> {
     const dbTx = await this._db.createTransactionRunner();
-    let res;
 
     try {
-      res = await this._db.updateBlockProgress(dbTx, block, lastProcessedEventIndex);
+      const updatedBlock = await this._db.updateBlockProgress(dbTx, block, lastProcessedEventIndex);
       await dbTx.commitTransaction();
+
+      return updatedBlock;
     } catch (error) {
       await dbTx.rollbackTransaction();
       throw error;
     } finally {
       await dbTx.release();
     }
-
-    return res;
   }
 
   async getEvent (id: string): Promise<EventInterface | undefined> {

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -3,7 +3,7 @@
 //
 
 import assert from 'assert';
-import { DeepPartial, FindConditions, Not } from 'typeorm';
+import { DeepPartial, FindConditions, FindManyOptions, Not } from 'typeorm';
 import debug from 'debug';
 import { ethers } from 'ethers';
 
@@ -204,8 +204,8 @@ export class Indexer {
     return events;
   }
 
-  async getBlockEvents (blockHash: string): Promise<Array<EventInterface>> {
-    return this._db.getBlockEvents(blockHash);
+  async getBlockEvents (blockHash: string, options: FindManyOptions<EventInterface> = {}): Promise<Array<EventInterface>> {
+    return this._db.getBlockEvents(blockHash, options);
   }
 
   async getEventsByFilter (blockHash: string, contract: string, name: string | null): Promise<Array<EventInterface>> {
@@ -228,7 +228,7 @@ export class Indexer {
       where.eventName = name;
     }
 
-    const events = await this._db.getBlockEvents(blockHash, where);
+    const events = await this._db.getBlockEvents(blockHash, { where });
     log(`getEvents: db hit, num events: ${events.length}`);
 
     return events;

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -97,7 +97,7 @@ export class JobQueue {
     assert(this._boss);
 
     const jobId = await this._boss.publish(queue, job, options);
-    log(`Created job in queue ${queue}: ${jobId} data: ${job.id}`);
+    log(`Created job in queue ${queue}: ${jobId}`);
   }
 
   async deleteAllJobs (): Promise<void> {

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -60,22 +60,17 @@ export class JobQueue {
     return await this._boss.subscribe(
       queue,
       {
-        includeMetadata: true,
-        batchSize: JOBS_PER_INTERVAL
+        teamSize: JOBS_PER_INTERVAL,
+        teamConcurrency: 1
       },
-      async (jobs: any) => {
-        // TODO: Debug jobs not fetched in order from database and use teamSize instead of batchSize.
-        jobs = jobs.sort((a: any, b: any) => a.createdon - b.createdon);
-
-        for (const job of jobs) {
-          try {
-            log(`Processing queue ${queue} job ${job.id}...`);
-            await callback(job);
-          } catch (error) {
-            log(`Error in queue ${queue} job ${job.id}`);
-            log(error);
-            throw error;
-          }
+      async (job: any) => {
+        try {
+          log(`Processing queue ${queue} job ${job.id}...`);
+          await callback(job);
+        } catch (error) {
+          log(`Error in queue ${queue} job ${job.id}`);
+          log(error);
+          throw error;
         }
       }
     );

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -13,7 +13,7 @@ import { EventInterface, IndexerInterface, SyncStatusInterface, BlockProgressInt
 import { wait } from './misc';
 import { createPruningJob } from './common';
 
-const EVENTS_IN_BATCH = 50;
+const DEFAULT_EVENTS_IN_BATCH = 50;
 
 const log = debug('vulcanize:job-runner');
 
@@ -194,7 +194,7 @@ export class JobRunner {
       const events: EventInterface[] = await this._indexer.getBlockEvents(
         blockHash,
         {
-          take: EVENTS_IN_BATCH,
+          take: this._jobQueueConfig.eventsInBatch || DEFAULT_EVENTS_IN_BATCH,
           where: {
             index: MoreThanOrEqual(block.lastProcessedEventIndex + 1)
           },

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -52,7 +52,7 @@ export interface IndexerInterface {
   getSyncStatus (): Promise<SyncStatusInterface | undefined>;
   getBlocks (blockFilter: { blockHash?: string, blockNumber?: number }): Promise<any>
   getBlocksAtHeight (height: number, isPruned: boolean): Promise<BlockProgressInterface[]>;
-  getBlockEvents (blockHash: string): Promise<Array<EventInterface>>
+  getBlockEvents (blockHash: string, options: FindManyOptions<EventInterface>): Promise<Array<EventInterface>>
   getAncestorAtDepth (blockHash: string, depth: number): Promise<string>
   getOrFetchBlockEvents (block: DeepPartial<BlockProgressInterface>): Promise<Array<EventInterface>>
   removeUnknownEvents (block: BlockProgressInterface): Promise<void>
@@ -79,7 +79,7 @@ export interface DatabaseInterface {
   createTransactionRunner(): Promise<QueryRunner>;
   getBlocksAtHeight (height: number, isPruned: boolean): Promise<BlockProgressInterface[]>;
   getBlockProgress (blockHash: string): Promise<BlockProgressInterface | undefined>;
-  getBlockEvents (blockHash: string, where?: FindConditions<EventInterface>): Promise<EventInterface[]>;
+  getBlockEvents (blockHash: string, where?: FindManyOptions<EventInterface>): Promise<EventInterface[]>;
   getEvent (id: string): Promise<EventInterface | undefined>
   getSyncStatus (queryRunner: QueryRunner): Promise<SyncStatusInterface | undefined>
   getAncestorAtDepth (blockHash: string, depth: number): Promise<string>


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/305

* Avoid block progress query by using updated entity returned from update query.
* Process batch of events for a block in a single job.
* Fix smoke test to listen for subscribed events together as they are published very closely.
* Use teamSize instead of batchSize for job queue.
