### PR TITLE
Performance improvements for fill CLI

### DIFF
--- a/packages/erc20-watcher/src/entity/BlockProgress.ts
+++ b/packages/erc20-watcher/src/entity/BlockProgress.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, Index, CreateDateColumn } from 'typeorm';
 
 import { BlockProgressInterface } from '@vulcanize/util';
 
@@ -40,4 +40,7 @@ export class BlockProgress implements BlockProgressInterface {
 
   @Column('boolean', { default: false })
   isPruned!: boolean
+
+  @CreateDateColumn()
+  createdAt!: Date;
 }

--- a/packages/erc20-watcher/src/fill.ts
+++ b/packages/erc20-watcher/src/fill.ts
@@ -50,7 +50,7 @@ export const main = async (): Promise<any> => {
     },
     batchBlocks: {
       type: 'number',
-      default: 5,
+      default: 10,
       describe: 'Number of blocks prefetched in batch'
     }
   }).argv;

--- a/packages/erc20-watcher/src/fill.ts
+++ b/packages/erc20-watcher/src/fill.ts
@@ -42,6 +42,16 @@ export const main = async (): Promise<any> => {
       require: true,
       demandOption: true,
       describe: 'Block number to stop processing at'
+    },
+    prefetch: {
+      type: 'boolean',
+      default: false,
+      describe: 'Block and events prefetch mode'
+    },
+    batchBlocks: {
+      type: 'number',
+      default: 5,
+      describe: 'Number of blocks prefetched in batch'
     }
   }).argv;
 
@@ -90,7 +100,7 @@ export const main = async (): Promise<any> => {
 
   assert(jobQueueConfig, 'Missing job queue config');
 
-  await fillBlocks(jobQueue, indexer, postgraphileClient, eventWatcher, blockDelayInMilliSecs, argv);
+  await fillBlocks(jobQueue, indexer, eventWatcher, blockDelayInMilliSecs, argv);
 };
 
 main().catch(err => {

--- a/packages/uni-info-watcher/src/entity/BlockProgress.ts
+++ b/packages/uni-info-watcher/src/entity/BlockProgress.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, Index, CreateDateColumn } from 'typeorm';
 
 import { BlockProgressInterface } from '@vulcanize/util';
 
@@ -40,4 +40,7 @@ export class BlockProgress implements BlockProgressInterface {
 
   @Column('boolean', { default: false })
   isPruned!: boolean
+
+  @CreateDateColumn()
+  createdAt!: Date;
 }

--- a/packages/uni-info-watcher/src/fill.ts
+++ b/packages/uni-info-watcher/src/fill.ts
@@ -52,7 +52,7 @@ export const main = async (): Promise<any> => {
     },
     batchBlocks: {
       type: 'number',
-      default: 5,
+      default: 10,
       describe: 'Number of blocks prefetched in batch'
     }
   }).argv;

--- a/packages/uni-info-watcher/src/fill.ts
+++ b/packages/uni-info-watcher/src/fill.ts
@@ -44,6 +44,16 @@ export const main = async (): Promise<any> => {
       require: true,
       demandOption: true,
       describe: 'Block number to stop processing at'
+    },
+    prefetch: {
+      type: 'boolean',
+      default: false,
+      describe: 'Block and events prefetch mode'
+    },
+    batchBlocks: {
+      type: 'number',
+      default: 5,
+      describe: 'Number of blocks prefetched in batch'
     }
   }).argv;
 
@@ -94,7 +104,7 @@ export const main = async (): Promise<any> => {
 
   const eventWatcher = new EventWatcher(upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
 
-  await fillBlocks(jobQueue, indexer, postgraphileClient, eventWatcher, blockDelayInMilliSecs, argv);
+  await fillBlocks(jobQueue, indexer, eventWatcher, blockDelayInMilliSecs, argv);
 };
 
 main().catch(err => {

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -363,9 +363,7 @@ export class Indexer implements IndexerInterface {
   async _fetchAndSaveEvents (block: DeepPartial<BlockProgress>): Promise<BlockProgress> {
     assert(block.blockHash);
 
-    console.time('time:indexer#_fetchAndSaveEvents-uni_watcher');
     const events = await this._uniClient.getEvents(block.blockHash);
-    console.timeEnd('time:indexer#_fetchAndSaveEvents-uni_watcher');
 
     const dbEvents: Array<DeepPartial<Event>> = [];
 

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -1104,7 +1104,7 @@ export class Indexer implements IndexerInterface {
 
       if (modulo === BigInt(0)) {
         // Current tick is initialized and needs to be updated.
-        this._loadTickUpdateFeeVarsAndSave(dbTx, Number(newTick), block, contractAddress);
+        await this._loadTickUpdateFeeVarsAndSave(dbTx, Number(newTick), block, contractAddress);
       }
 
       const numIters = BigInt(
@@ -1124,13 +1124,13 @@ export class Indexer implements IndexerInterface {
         const firstInitialized = oldTick + tickSpacing - modulo;
 
         for (let i = firstInitialized; i < newTick; i = i + tickSpacing) {
-          this._loadTickUpdateFeeVarsAndSave(dbTx, Number(i), block, contractAddress);
+          await this._loadTickUpdateFeeVarsAndSave(dbTx, Number(i), block, contractAddress);
         }
       } else if (newTick < oldTick) {
         const firstInitialized = oldTick - modulo;
 
         for (let i = firstInitialized; i >= newTick; i = i - tickSpacing) {
-          this._loadTickUpdateFeeVarsAndSave(dbTx, Number(i), block, contractAddress);
+          await this._loadTickUpdateFeeVarsAndSave(dbTx, Number(i), block, contractAddress);
         }
       }
 

--- a/packages/uni-watcher/src/entity/BlockProgress.ts
+++ b/packages/uni-watcher/src/entity/BlockProgress.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, Index, CreateDateColumn } from 'typeorm';
 
 import { BlockProgressInterface } from '@vulcanize/util';
 
@@ -40,4 +40,7 @@ export class BlockProgress implements BlockProgressInterface {
 
   @Column('boolean', { default: false })
   isPruned!: boolean
+
+  @CreateDateColumn()
+  createdAt!: Date;
 }

--- a/packages/uni-watcher/src/fill.ts
+++ b/packages/uni-watcher/src/fill.ts
@@ -50,7 +50,7 @@ export const main = async (): Promise<any> => {
     },
     batchBlocks: {
       type: 'number',
-      default: 5,
+      default: 10,
       describe: 'Number of blocks prefetched in batch'
     }
   }).argv;

--- a/packages/uni-watcher/src/fill.ts
+++ b/packages/uni-watcher/src/fill.ts
@@ -42,6 +42,16 @@ export const main = async (): Promise<any> => {
       require: true,
       demandOption: true,
       describe: 'Block number to stop processing at'
+    },
+    prefetch: {
+      type: 'boolean',
+      default: false,
+      describe: 'Block and events prefetch mode'
+    },
+    batchBlocks: {
+      type: 'number',
+      default: 5,
+      describe: 'Number of blocks prefetched in batch'
     }
   }).argv;
 
@@ -91,7 +101,7 @@ export const main = async (): Promise<any> => {
 
   assert(jobQueueConfig, 'Missing job queue config');
 
-  await fillBlocks(jobQueue, indexer, postgraphileClient, eventWatcher, blockDelayInMilliSecs, argv);
+  await fillBlocks(jobQueue, indexer, eventWatcher, blockDelayInMilliSecs, argv);
 };
 
 main().catch(err => {

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -431,7 +431,6 @@ export class Indexer implements IndexerInterface {
   async _fetchAndSaveEvents ({ blockHash }: DeepPartial<BlockProgress>): Promise<BlockProgress> {
     assert(blockHash);
 
-    console.time('time:indexer#_fetchAndSaveEvents-logs_txs');
     const logsPromise = this._ethClient.getLogs({ blockHash });
     const transactionsPromise = this._postgraphileClient.getBlockWithTransactions({ blockHash });
 
@@ -449,8 +448,6 @@ export class Indexer implements IndexerInterface {
         }
       }
     ] = await Promise.all([logsPromise, transactionsPromise]);
-
-    console.timeEnd('time:indexer#_fetchAndSaveEvents-logs_txs');
 
     const transactionMap = transactions.reduce((acc: {[key: string]: any}, transaction: {[key: string]: any}) => {
       acc[transaction.txHash] = transaction;

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -10,7 +10,8 @@
     "ethers": "^5.2.0",
     "fs-extra": "^10.0.0",
     "pg-boss": "^6.1.0",
-    "toml": "^3.0.0"
+    "toml": "^3.0.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.11",
@@ -28,7 +29,6 @@
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",
     "hardhat": "^2.3.0",
-    "lodash": "^4.17.21",
     "typeorm": "^0.2.32",
     "typeorm-naming-strategies": "^2.0.0"
   },

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -56,12 +56,17 @@ export const processBlockByNumber = async (
     if (blocks.length) {
       for (let bi = 0; bi < blocks.length; bi++) {
         const { blockHash, blockNumber, parentHash, timestamp } = blocks[bi];
+
+        console.time('time:common#processBlockByNumber-get_block_progress');
         const blockProgress = await indexer.getBlockProgress(blockHash);
+        console.timeEnd('time:common#processBlockByNumber-get_block_progress');
 
         if (blockProgress) {
           log(`Block number ${blockNumber}, block hash ${blockHash} already processed`);
         } else {
+          console.time('time:common#processBlockByNumber-updateSyncStatusChainHead');
           await indexer.updateSyncStatusChainHead(blockHash, blockNumber);
+          console.timeEnd('time:common#processBlockByNumber-updateSyncStatusChainHead');
 
           await jobQueue.pushJob(QUEUE_BLOCK_PROCESSING, { kind: JOB_KIND_INDEX, blockHash, blockNumber, parentHash, timestamp });
         }

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -432,7 +432,9 @@ export class Database {
         FROM
           block_progress b
           LEFT JOIN
-            ${repo.metadata.tableName} e ON e.block_hash = b.block_hash
+            ${repo.metadata.tableName} e
+            ON e.block_hash = b.block_hash
+            AND e.id = $2
         WHERE
           b.block_hash = $1
         UNION ALL

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -146,18 +146,20 @@ export class EventWatcher {
     const { blockHash, blockNumber, priority } = jobData;
     log(`Job onComplete indexing block ${blockHash} ${blockNumber}`);
 
-    // Update sync progress.
-    const syncStatus = await this._indexer.updateSyncStatusIndexedBlock(blockHash, blockNumber);
+    const [blockProgress, syncStatus] = await Promise.all([
+      this._indexer.getBlockProgress(blockHash),
+      // Update sync progress.
+      this._indexer.updateSyncStatusIndexedBlock(blockHash, blockNumber)
+    ]);
+
+    // Publish block progress event.
+    if (blockProgress) {
+      await this.publishBlockProgressToSubscribers(blockProgress);
+    }
 
     // Create pruning job if required.
     if (syncStatus && syncStatus.latestIndexedBlockNumber > (syncStatus.latestCanonicalBlockNumber + MAX_REORG_DEPTH)) {
       await createPruningJob(this._jobQueue, syncStatus.latestCanonicalBlockNumber, priority);
-    }
-
-    // Publish block progress event.
-    const blockProgress = await this._indexer.getBlockProgress(blockHash);
-    if (blockProgress) {
-      await this.publishBlockProgressToSubscribers(blockProgress);
     }
   }
 

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -152,8 +152,9 @@ export class EventWatcher {
       this._indexer.updateSyncStatusIndexedBlock(blockHash, blockNumber)
     ]);
 
-    // Publish block progress event.
-    if (blockProgress) {
+    // Publish block progress event if no events exist.
+    // Event for blocks with events will be pusblished from eventProcessingCompleteHandler.
+    if (blockProgress && blockProgress.numEvents === 0) {
       await this.publishBlockProgressToSubscribers(blockProgress);
     }
 

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -141,7 +141,7 @@ export class Indexer {
           throw error;
         }
 
-        log('Block not found. Fetching block after eth_call.');
+        log('Block not found. Fetching block after RPC call.');
       }
     }
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -193,9 +193,9 @@ export class JobRunner {
   async _processEvents (job: any): Promise<void> {
     const { blockHash } = job.data;
 
-    console.time('time:job-runner#processEvents-get-block-process');
+    console.time('time:job-runner#_processEvents-get-block-process');
     let block = await this._indexer.getBlockProgress(blockHash);
-    console.timeEnd('time:job-runner#processEvents-get-block-process');
+    console.timeEnd('time:job-runner#_processEvents-get-block-process');
     assert(block);
 
     console.time('time:job-runner#_processEvents-events');

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -17,6 +17,7 @@ export interface BlockProgressInterface {
   lastProcessedEventIndex: number;
   isComplete: boolean;
   isPruned: boolean;
+  createdAt: Date;
 }
 
 export interface SyncStatusInterface {


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

- Fix fill CLI to work with watcher server.
- Output progress for the fill job.
- Add createdAt column to BlockProgress entity.
- Insert events for one block in multiple batches instead of one to handle block with lots of events.
- Implement prefetch option to fetch and save block and events in parallel with events processing.
- Fixed getPrevEntity query.