### PR TITLE
Update sync status after pruning before processing next block

### DIFF
--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -167,13 +167,5 @@ export class EventWatcher {
   async _handlePruningComplete (jobData: any): Promise<void> {
     const { pruneBlockHeight } = jobData;
     log(`Job onComplete pruning at height ${pruneBlockHeight}`);
-
-    const blocks = await this._indexer.getBlocksAtHeight(pruneBlockHeight, false);
-
-    // Only one canonical (not pruned) block should exist at the pruned height.
-    assert(blocks.length === 1);
-    const [block] = blocks;
-
-    await this._indexer.updateSyncStatusCanonicalBlock(block.blockHash, block.blockNumber);
   }
 }

--- a/packages/util/src/fill.ts
+++ b/packages/util/src/fill.ts
@@ -131,6 +131,12 @@ const prefetchBlocks = async (
       }
     });
 
-    await Promise.all(fetchBlockPromises);
+    try {
+      await Promise.all(fetchBlockPromises);
+    } catch (error: any) {
+      log(error.message);
+      log('Exiting gracefully');
+      process.exit(0);
+    }
   }
 };


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

Update sync status after pruning before processing next block:
(Earlier, the sync status was being updated when the next block processing was already started.
As a result it would throw an error and recreate the pruning job unnecessarily)