### PR TITLE
Remove unknown events of parent block while processing a block

### DIFF
--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -109,10 +109,6 @@ export class EventWatcher {
 
     await this.publishBlockProgressToSubscribers(blockProgress);
 
-    if (blockProgress.isComplete) {
-      await this._indexer.removeUnknownEvents(blockProgress);
-    }
-
     return this._indexer.getBlockEvents(
       blockProgress.blockHash,
       {

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -203,6 +203,9 @@ export class JobRunner {
         }, { priority: newPriority });
 
         throw new Error(message);
+      } else {
+        // Remove the unknown events of the parent block if it is marked complete.
+        await this._indexer.removeUnknownEvents(parentBlock);
       }
     } else {
       blockProgress = parentBlock;


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

- Remove unknown events of parent block when processing a block
  (Earlier, when the removal of unknown events was being done in a complete handler of events job, the removal query might take time and not execute before the process is interrupted / exited).