### PR TITLE
Fix multiple block processing after restarting fill or server

### DIFF
--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -87,6 +87,8 @@ export const processBlockByNumber = async (
         }
       }
 
+      await indexer.updateSyncStatusChainHead(blocks[0].blockHash, blocks[0].blockNumber);
+
       return;
     }
 

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -77,7 +77,7 @@ export class EventWatcher {
       const { onBlockProgressEvent: { blockNumber, isComplete } } = data;
 
       if (isComplete) {
-        processBlockByNumber(this._jobQueue, this._indexer, blockDelayInMilliSecs, blockNumber + 1);
+        await processBlockByNumber(this._jobQueue, this._indexer, blockDelayInMilliSecs, blockNumber + 1);
       }
     }
   }


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

Sync status chain head block number was stale when checked before pushing to job queue.
Move update sync status outside job-runner so that latest value is fetched before pushing block processing job. 