### PR TITLE
Implement lazy update block progress after all events processed

### DIFF
--- a/packages/uni-watcher/environments/local.toml
+++ b/packages/uni-watcher/environments/local.toml
@@ -30,3 +30,4 @@
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 0
   eventsInBatch = 50
+  lazyUpdateBlockProgress = true

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -431,6 +431,7 @@ export class Indexer implements IndexerInterface {
   async _fetchAndSaveEvents ({ blockHash }: DeepPartial<BlockProgress>): Promise<BlockProgress> {
     assert(blockHash);
 
+    console.time('time:indexer#_fetchAndSaveEvents-get-logs-txs');
     const logsPromise = this._ethClient.getLogs({ blockHash });
     const transactionsPromise = this._postgraphileClient.getBlockWithTransactions({ blockHash });
 
@@ -448,6 +449,7 @@ export class Indexer implements IndexerInterface {
         }
       }
     ] = await Promise.all([logsPromise, transactionsPromise]);
+    console.timeEnd('time:indexer#_fetchAndSaveEvents-get-logs-txs');
 
     const transactionMap = transactions.reduce((acc: {[key: string]: any}, transaction: {[key: string]: any}) => {
       acc[transaction.txHash] = transaction;
@@ -522,8 +524,10 @@ export class Indexer implements IndexerInterface {
         parentHash: block.parent?.hash
       };
 
+      console.time('time:indexer#_fetchAndSaveEvents-save-events-block');
       const blockProgress = await this._db.saveEvents(dbTx, block, dbEvents);
       await dbTx.commitTransaction();
+      console.timeEnd('time:indexer#_fetchAndSaveEvents-save-events-block');
 
       return blockProgress;
     } catch (error) {

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -22,6 +22,7 @@ export interface JobQueueConfig {
   maxCompletionLagInSecs: number;
   jobDelayInMilliSecs?: number;
   eventsInBatch: number;
+  lazyUpdateBlockProgress?: boolean;
 }
 
 interface ServerConfig {

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -173,17 +173,17 @@ export class Database {
       if (block.numProcessedEvents >= block.numEvents) {
         block.isComplete = true;
       }
-
-      const { generatedMaps } = await repo.createQueryBuilder()
-        .update()
-        .set(block)
-        .where('id = :id', { id: block.id })
-        .whereEntity(block)
-        .returning('*')
-        .execute();
-
-      block = generatedMaps[0] as BlockProgressInterface;
     }
+
+    const { generatedMaps } = await repo.createQueryBuilder()
+      .update()
+      .set(block)
+      .where('id = :id', { id: block.id })
+      .whereEntity(block)
+      .returning('*')
+      .execute();
+
+    block = generatedMaps[0] as BlockProgressInterface;
 
     return block;
   }

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -198,7 +198,9 @@ export class Indexer {
     assert(block.blockHash);
 
     log(`getBlockEvents: fetching from upstream server ${block.blockHash}`);
+    console.time('time:indexer#fetchBlockEvents-fetchAndSaveEvents');
     const blockProgress = await fetchAndSaveEvents(block);
+    console.timeEnd('time:indexer#fetchBlockEvents-fetchAndSaveEvents');
     log(`getBlockEvents: fetched for block: ${blockProgress.blockHash} num events: ${blockProgress.numEvents}`);
 
     return blockProgress;

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -33,7 +33,9 @@ export class JobRunner {
   async processBlock (job: any): Promise<void> {
     const { data: { kind } } = job;
 
+    console.time('time:job-runner#processBlock-getSyncStatus');
     const syncStatus = await this._indexer.getSyncStatus();
+    console.timeEnd('time:job-runner#processBlock-getSyncStatus');
     assert(syncStatus);
 
     switch (kind) {
@@ -140,6 +142,7 @@ export class JobRunner {
       throw new Error(message);
     }
 
+    console.time('time:job-runner#_indexBlock-getBlockProgressEntities');
     let [parentBlock, blockProgress] = await this._indexer.getBlockProgressEntities(
       {
         blockHash: In([parentHash, blockHash])
@@ -150,6 +153,7 @@ export class JobRunner {
         }
       }
     );
+    console.timeEnd('time:job-runner#_indexBlock-getBlockProgressEntities');
 
     // Check if parent block has been processed yet, if not, push a high priority job to process that first and abort.
     // However, don't go beyond the `latestCanonicalBlockHash` from SyncStatus as we have to assume the reorg can't be that deep.


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

- Add a flag to lazy update block progress after all events processed
- Used in watchers where it does not affect event processing like uni-watcher