### PR TITLE
Fixes in mapping code and update new changes from subgraph 

### DIFF
--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -122,12 +122,16 @@ export class Database implements DatabaseInterface {
     return entity;
   }
 
-  async getToken (queryRunner: QueryRunner, { id, blockHash }: DeepPartial<Token>): Promise<Token | undefined> {
+  async getToken (queryRunner: QueryRunner, { id, blockHash, blockNumber }: DeepPartial<Token>): Promise<Token | undefined> {
     const repo = queryRunner.manager.getRepository(Token);
     const whereOptions: FindConditions<Token> = { id };
 
     if (blockHash) {
       whereOptions.blockHash = blockHash;
+    }
+
+    if (blockNumber) {
+      whereOptions.blockNumber = LessThanOrEqual(blockNumber);
     }
 
     const findOptions = {

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -296,6 +296,11 @@ export class Indexer implements IndexerInterface {
         return acc;
       }, {});
 
+      if (!queryOptions.orderBy) {
+        // Default order by id.
+        queryOptions.orderBy = 'id';
+      }
+
       res = await this._db.getModelEntities(dbTx, entity, block, where, queryOptions, relations);
       dbTx.commitTransaction();
     } catch (error) {
@@ -596,8 +601,8 @@ export class Indexer implements IndexerInterface {
       // Currently fetching first factory in database as only one exists.
       const [factory] = await this._db.getModelEntities(dbTx, Factory, { hash: block.hash }, {}, { limit: 1 });
 
-      let token0 = await this._db.getToken(dbTx, pool.token0);
-      let token1 = await this._db.getToken(dbTx, pool.token1);
+      let token0 = await this._db.getToken(dbTx, { id: pool.token0.id, blockHash: block.hash });
+      let token1 = await this._db.getToken(dbTx, { id: pool.token1.id, blockHash: block.hash });
       assert(token0);
       assert(token1);
       const amount0 = convertTokenToDecimal(BigInt(mintEvent.amount0), BigInt(token0.decimals));
@@ -756,8 +761,8 @@ export class Indexer implements IndexerInterface {
       // Currently fetching first factory in database as only one exists.
       const [factory] = await this._db.getModelEntities(dbTx, Factory, { hash: block.hash }, {}, { limit: 1 });
 
-      let token0 = await this._db.getToken(dbTx, pool.token0);
-      let token1 = await this._db.getToken(dbTx, pool.token1);
+      let token0 = await this._db.getToken(dbTx, { id: pool.token0.id, blockHash: block.hash });
+      let token1 = await this._db.getToken(dbTx, { id: pool.token1.id, blockHash: block.hash });
       assert(token0);
       assert(token1);
       const amount0 = convertTokenToDecimal(BigInt(burnEvent.amount0), BigInt(token0.decimals));
@@ -1231,8 +1236,8 @@ export class Indexer implements IndexerInterface {
       const amount1 = convertTokenToDecimal(BigInt(event.amount1), BigInt(token1.decimals));
 
       position.liquidity = BigInt(position.liquidity) - BigInt(event.liquidity);
-      position.depositedToken0 = position.depositedToken0.plus(amount0);
-      position.depositedToken1 = position.depositedToken1.plus(amount1);
+      position.withdrawnToken0 = position.withdrawnToken0.plus(amount0);
+      position.withdrawnToken1 = position.withdrawnToken1.plus(amount1);
 
       await this._db.savePosition(dbTx, position, block);
 

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -1259,6 +1259,7 @@ export class Indexer implements IndexerInterface {
       return;
     }
 
+    // Temp fix from Subgraph mapping code.
     if (utils.getAddress(position.pool.id) === utils.getAddress('0x8fe8d9bb8eeba3ed688069c3d6b556c9ca258248')) {
       return;
     }
@@ -1272,6 +1273,14 @@ export class Indexer implements IndexerInterface {
         position.transaction = transaction;
         position = await this._db.savePosition(dbTx, position, block);
       }
+
+      const token0 = position.token0;
+      const token1 = position.token1;
+      const amount0 = convertTokenToDecimal(BigInt(event.amount0), BigInt(token0.decimals));
+      const amount1 = convertTokenToDecimal(BigInt(event.amount1), BigInt(token1.decimals));
+
+      position.collectedFeesToken0 = position.collectedFeesToken0.plus(amount0);
+      position.collectedFeesToken1 = position.collectedFeesToken1.plus(amount1);
 
       await this._db.savePosition(dbTx, position, block);
 

--- a/packages/uni-info-watcher/src/schema.ts
+++ b/packages/uni-info-watcher/src/schema.ts
@@ -372,6 +372,7 @@ type Query {
 
   pool(
     id: ID!
+    block: Block_height
   ): Pool
 
   poolDayDatas(

--- a/packages/uni-info-watcher/src/utils/pricing.ts
+++ b/packages/uni-info-watcher/src/utils/pricing.ts
@@ -44,15 +44,6 @@ export const WHITELIST_TOKENS: string[] = [
   '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9' // AAVE
 ];
 
-const STABLE_COINS: string[] = [
-  '0x6b175474e89094c44da98b954eedeac495271d0f',
-  '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  '0xdac17f958d2ee523a2206206994597c13d831ec7',
-  '0x0000000000085d4780b73119b644ae5ecd22b376',
-  '0x956f47f50a910163d8bf957cf5846d573e7f87ca',
-  '0x4dd28568d05f09b02220b09c2cb307bfd837cb95'
-];
-
 const MINIMUM_ETH_LOCKED = new GraphDecimal(52);
 const Q192 = 2 ** 192;
 
@@ -104,37 +95,30 @@ export const findEthPerToken = async (db: Database, dbTx: QueryRunner, token: To
   // Need to update this to actually detect best rate based on liquidity distribution.
   let largestLiquidityETH = new GraphDecimal(0);
   let priceSoFar = new GraphDecimal(0);
-  const bundle = await db.getBundle(dbTx, { id: '1' });
-  assert(bundle);
 
-  // hardcoded fix for incorrect rates
-  // if whitelist includes token - get the safe price
-  if (STABLE_COINS.includes(token.id)) {
-    priceSoFar = safeDiv(new GraphDecimal(1), bundle.ethPriceUSD);
-  } else {
-    for (let i = 0; i < whiteList.length; ++i) {
-      const poolAddress = whiteList[i].id;
-      const pool = await db.getPool(dbTx, { id: poolAddress });
-      assert(pool);
+  for (let i = 0; i < whiteList.length; ++i) {
+    const poolAddress = whiteList[i].id;
+    const pool = await db.getPool(dbTx, { id: poolAddress });
+    assert(pool);
 
-      if (BigNumber.from(pool.liquidity).gt(0)) {
-        if (pool.token0.id === token.id) {
-          // whitelist token is token1
-          const token1 = pool.token1;
+    if (BigNumber.from(pool.liquidity).gt(0)) {
+      if (pool.token0.id === token.id) {
+        // whitelist token is token1
+        const token1 = pool.token1;
 
-          // get the derived ETH in pool
-          const ethLocked = pool.totalValueLockedToken1.times(token1.derivedETH);
+        // get the derived ETH in pool
+        const ethLocked = pool.totalValueLockedToken1.times(token1.derivedETH);
 
-          if (ethLocked.gt(largestLiquidityETH) && ethLocked.gt(MINIMUM_ETH_LOCKED)) {
-            largestLiquidityETH = ethLocked;
-            // token1 per our token * Eth per token1
-            priceSoFar = pool.token1Price.times(token1.derivedETH);
-          }
+        if (ethLocked.gt(largestLiquidityETH) && ethLocked.gt(MINIMUM_ETH_LOCKED)) {
+          largestLiquidityETH = ethLocked;
+          // token1 per our token * Eth per token1
+          priceSoFar = pool.token1Price.times(token1.derivedETH);
         }
       }
       if (pool.token1.id === token.id) {
         const token0 = pool.token0;
-        // Get the derived ETH in pool.
+
+        // get the derived ETH in pool
         const ethLocked = pool.totalValueLockedToken0.times(token0.derivedETH);
 
         if (ethLocked.gt(largestLiquidityETH) && ethLocked.gt(MINIMUM_ETH_LOCKED)) {

--- a/packages/uni-info-watcher/src/utils/tick.ts
+++ b/packages/uni-info-watcher/src/utils/tick.ts
@@ -38,9 +38,6 @@ export const feeTierToTickSpacing = (feeTier: bigint): bigint => {
   if (feeTier === BigInt(500)) {
     return BigInt(10);
   }
-  if (feeTier === BigInt(100)) {
-    return BigInt(1);
-  }
 
   throw Error('Unexpected fee tier');
 };

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -361,6 +361,8 @@ export class Database {
       .where(`${tableName}.block_number IN (${subQuery.getQuery()})`)
       .setParameters(subQuery.getParameters());
 
+    selectQueryBuilder = this._buildQuery(repo, selectQueryBuilder, where, queryOptions);
+
     relations.forEach(relation => {
       let alias, property;
 
@@ -373,9 +375,8 @@ export class Database {
       }
 
       selectQueryBuilder = selectQueryBuilder.leftJoinAndSelect(property, alias);
+      selectQueryBuilder.addOrderBy(`${alias}.id`);
     });
-
-    selectQueryBuilder = this._buildQuery(repo, selectQueryBuilder, where, queryOptions);
 
     const { limit = DEFAULT_LIMIT, skip = DEFAULT_SKIP } = queryOptions;
 
@@ -572,7 +573,7 @@ export class Database {
     if (orderBy) {
       const columnMetadata = repo.metadata.findColumnWithPropertyName(orderBy);
       assert(columnMetadata);
-      selectQueryBuilder = selectQueryBuilder.orderBy(`${tableName}.${columnMetadata.propertyAliasName}`, orderDirection === 'desc' ? 'DESC' : 'ASC');
+      selectQueryBuilder = selectQueryBuilder.addOrderBy(`${tableName}.${columnMetadata.propertyAliasName}`, orderDirection === 'desc' ? 'DESC' : 'ASC');
     }
 
     return selectQueryBuilder;


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

- Order entities and related entities in query by id.
- Fix fetching latest entities from db in mapping code.
- Fix Position entity depositedToken in mapping code
- Update uni-info-watcher according to mapping code in https://github.com/vulcanize/uniswap-v3-subgraph/tree/watcher-ts-12369621 (branch created from previous commit).
  Previous commit is used as the new changes use subgraph grafting (https://thegraph.com/docs/en/developer/create-subgraph-hosted/#grafting-onto-existing-subgraphs). So for the initial blocks the entities do not match. Grafting modified at different commits:
  1. https://github.com/Uniswap/v3-subgraph/commit/ff07a11ec5aa9112585f72ff052c3b2fce87c14c
      ```
      base: QmRvEgUpbjVV326W2zPvxWimzQwcDREfjejUdFn2L92qry
      block: 13498328
      ```
  2. https://github.com/Uniswap/v3-subgraph/commit/ef7504fcac29f8804d32ba6ec2c2da66697ecc36
      ```
      base: QmS13421u6qsbVdBCrZhdRaZw2wH67drwF3urmueJvvJ5P
      block: 13591197
      ```