### PR TITLE
Fixes in uni-info-watcher code for subgraph entities mismatch

### DIFF
--- a/packages/codegen/src/templates/database-template.handlebars
+++ b/packages/codegen/src/templates/database-template.handlebars
@@ -186,7 +186,7 @@ export class Database {
     return this._baseDatabase.updateBlockProgress(repo, blockHash, lastProcessedEventIndex);
   }
 
-  async removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindManyOptions<Entity> | FindConditions<Entity>): Promise<void> {
+  async removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindConditions<Entity>): Promise<void> {
     return this._baseDatabase.removeEntities(queryRunner, entity, findConditions);
   }
 

--- a/packages/erc20-watcher/src/database.ts
+++ b/packages/erc20-watcher/src/database.ts
@@ -184,7 +184,7 @@ export class Database {
     return this._baseDatabase.updateBlockProgress(repo, block, lastProcessedEventIndex);
   }
 
-  async removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindManyOptions<Entity> | FindConditions<Entity>): Promise<void> {
+  async removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindConditions<Entity>): Promise<void> {
     return this._baseDatabase.removeEntities(queryRunner, entity, findConditions);
   }
 

--- a/packages/uni-info-watcher/src/cli/reset-cmds/state.ts
+++ b/packages/uni-info-watcher/src/cli/reset-cmds/state.ts
@@ -22,6 +22,14 @@ import { Swap } from '../../entity/Swap';
 import { PositionSnapshot } from '../../entity/PositionSnapshot';
 import { Position } from '../../entity/Position';
 import { Token } from '../../entity/Token';
+import { PoolDayData } from '../../entity/PoolDayData';
+import { PoolHourData } from '../../entity/PoolHourData';
+import { Tick } from '../../entity/Tick';
+import { TickDayData } from '../../entity/TickDayData';
+import { TokenDayData } from '../../entity/TokenDayData';
+import { TokenHourData } from '../../entity/TokenHourData';
+import { Transaction } from '../../entity/Transaction';
+import { UniswapDayData } from '../../entity/UniswapDayData';
 
 const log = debug('vulcanize:reset-state');
 
@@ -74,7 +82,26 @@ export const handler = async (argv: any): Promise<void> => {
   const dbTx = await db.createTransactionRunner();
 
   try {
-    const removeEntitiesPromise = [BlockProgress, Factory, Bundle, Pool, Mint, Burn, Swap, PositionSnapshot, Position, Token].map(async entityClass => {
+    const removeEntitiesPromise = [
+      BlockProgress,
+      Factory,
+      Bundle,
+      Pool,
+      Mint,
+      Burn,
+      Swap,
+      PositionSnapshot,
+      Position,
+      Token,
+      PoolDayData,
+      PoolHourData,
+      Tick,
+      TickDayData,
+      TokenDayData,
+      TokenHourData,
+      Transaction,
+      UniswapDayData
+    ].map(async entityClass => {
       return db.removeEntities<any>(dbTx, entityClass, { blockNumber: MoreThan(argv.blockNumber) });
     });
 

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -317,7 +317,8 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      }
+      },
+      relations: ['pool']
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<PoolHourData>);
@@ -365,7 +366,8 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      }
+      },
+      relations: ['token']
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<TokenDayData>);
@@ -389,7 +391,8 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      }
+      },
+      relations: ['token']
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<TokenHourData>);
@@ -413,7 +416,8 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      }
+      },
+      relations: ['tick', 'pool']
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<TickDayData>);

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -692,7 +692,7 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.getEntities(queryRunner, entity, findConditions);
   }
 
-  async removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindManyOptions<Entity> | FindConditions<Entity>): Promise<void> {
+  async removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindConditions<Entity>): Promise<void> {
     return this._baseDatabase.removeEntities(queryRunner, entity, findConditions);
   }
 

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -848,9 +848,9 @@ export class Indexer implements IndexerInterface {
 
       await updateUniswapDayData(this._db, dbTx, { block, contractAddress });
       await updateTokenDayData(this._db, dbTx, token0, { block });
-      await updateTokenDayData(this._db, dbTx, token0, { block });
+      await updateTokenDayData(this._db, dbTx, token1, { block });
       await updateTokenHourData(this._db, dbTx, token0, { block });
-      await updateTokenHourData(this._db, dbTx, token0, { block });
+      await updateTokenHourData(this._db, dbTx, token1, { block });
       await updatePoolDayData(this._db, dbTx, { block, contractAddress });
       await updatePoolHourData(this._db, dbTx, { block, contractAddress });
       await this._updateTickFeeVarsAndSave(dbTx, lowerTick, block);
@@ -995,6 +995,7 @@ export class Indexer implements IndexerInterface {
       const prices = sqrtPriceX96ToTokenPrices(pool.sqrtPrice, token0 as Token, token1 as Token);
       pool.token0Price = prices[0];
       pool.token1Price = prices[1];
+      await this._db.savePool(dbTx, pool, block);
 
       // Update USD pricing.
       bundle.ethPriceUSD = await getEthPriceInUSD(this._db, dbTx, block, this._isDemo);
@@ -1043,9 +1044,9 @@ export class Indexer implements IndexerInterface {
       const poolDayData = await updatePoolDayData(this._db, dbTx, { block, contractAddress });
       const poolHourData = await updatePoolHourData(this._db, dbTx, { block, contractAddress });
       const token0DayData = await updateTokenDayData(this._db, dbTx, token0, { block });
-      const token1DayData = await updateTokenDayData(this._db, dbTx, token0, { block });
+      const token1DayData = await updateTokenDayData(this._db, dbTx, token1, { block });
       const token0HourData = await updateTokenHourData(this._db, dbTx, token0, { block });
-      const token1HourData = await updateTokenHourData(this._db, dbTx, token0, { block });
+      const token1HourData = await updateTokenHourData(this._db, dbTx, token1, { block });
 
       // Update volume metrics.
       uniswapDayData.volumeETH = uniswapDayData.volumeETH.plus(amountTotalETHTracked);

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -566,8 +566,8 @@ export class Indexer implements IndexerInterface {
       await updatePoolDayData(this._db, dbTx, { contractAddress, block });
       await updatePoolHourData(this._db, dbTx, { contractAddress, block });
 
-      token0.derivedETH = await findEthPerToken(this._db, dbTx, token0, this._isDemo);
-      token1.derivedETH = await findEthPerToken(this._db, dbTx, token1, this._isDemo);
+      token0.derivedETH = await findEthPerToken(this._db, dbTx, token0, block, this._isDemo);
+      token1.derivedETH = await findEthPerToken(this._db, dbTx, token1, block, this._isDemo);
 
       await this._db.saveBundle(dbTx, bundle, block);
 
@@ -1000,8 +1000,8 @@ export class Indexer implements IndexerInterface {
       // Update USD pricing.
       bundle.ethPriceUSD = await getEthPriceInUSD(this._db, dbTx, block, this._isDemo);
       bundle = await this._db.saveBundle(dbTx, bundle, block);
-      token0.derivedETH = await findEthPerToken(this._db, dbTx, token0, this._isDemo);
-      token1.derivedETH = await findEthPerToken(this._db, dbTx, token1, this._isDemo);
+      token0.derivedETH = await findEthPerToken(this._db, dbTx, token0, block, this._isDemo);
+      token1.derivedETH = await findEthPerToken(this._db, dbTx, token1, block, this._isDemo);
 
       /**
        * Things afffected by new USD rates.

--- a/packages/uni-info-watcher/src/resolvers.ts
+++ b/packages/uni-info-watcher/src/resolvers.ts
@@ -21,10 +21,10 @@ import { Tick } from './entity/Tick';
 import { Token } from './entity/Token';
 import { TokenDayData } from './entity/TokenDayData';
 import { TokenHourData } from './entity/TokenHourData';
-import { Transaction } from './entity/Transaction';
 import { UniswapDayData } from './entity/UniswapDayData';
 import { Position } from './entity/Position';
 import { EventWatcher } from './events';
+import { Transaction } from './entity/Transaction';
 
 const log = debug('vulcanize:resolver');
 
@@ -146,13 +146,13 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
         return indexer.getEntities(TokenHourData, block, where, { limit: first, skip, orderBy, orderDirection });
       },
 
-      transactions: async (_: any, { block = {}, first, orderBy, orderDirection }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection}) => {
+      transactions: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('transactions', first, orderBy, orderDirection);
 
         return indexer.getEntities(
           Transaction,
           block,
-          {},
+          where,
           { limit: first, orderBy, orderDirection },
           [
             'transaction.mints',

--- a/packages/uni-info-watcher/src/schema.ts
+++ b/packages/uni-info-watcher/src/schema.ts
@@ -213,6 +213,7 @@ input Mint_filter {
   pool: String
   token0: String
   token1: String
+  id: ID
 }
 
 enum Mint_orderBy {
@@ -249,6 +250,10 @@ input UniswapDayData_filter {
 
 enum Transaction_orderBy {
   timestamp
+}
+
+input Transaction_filter {
+  id: ID
 }
 
 input Token_filter {
@@ -460,6 +465,7 @@ type Query {
     first: Int = 100
     orderBy: Transaction_orderBy
     orderDirection: OrderDirection
+    where: Transaction_filter
     block: Block_height
   ): [Transaction!]!
 

--- a/packages/uni-watcher/src/database.ts
+++ b/packages/uni-watcher/src/database.ts
@@ -159,7 +159,7 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.getEntities(queryRunner, entity, findConditions);
   }
 
-  async removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindManyOptions<Entity> | FindConditions<Entity>): Promise<void> {
+  async removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindConditions<Entity>): Promise<void> {
     return this._baseDatabase.removeEntities(queryRunner, entity, findConditions);
   }
 

--- a/packages/util/src/fill.ts
+++ b/packages/util/src/fill.ts
@@ -118,7 +118,20 @@ const prefetchBlocks = async (
       const blockProgress = await indexer.getBlockProgress(blockHash);
 
       if (!blockProgress) {
-        await indexer.fetchBlockEvents({ blockHash, blockNumber, parentHash, blockTimestamp: timestamp });
+        const events = await indexer.fetchBlockEvents({ blockHash });
+
+        // Save block progress in database.
+        await indexer.saveBlockProgress({
+          blockHash,
+          blockNumber,
+          parentHash,
+          blockTimestamp: timestamp,
+          numEvents: events.length,
+          isComplete: events.length === 0
+        });
+
+        // In fill prefetch, not saving events to database as now events are saved after processing them in job-runner.
+        // Saving them in fill prefetch will result to error when events get saved after processing.
       }
     });
 

--- a/packages/util/src/graph-decimal.ts
+++ b/packages/util/src/graph-decimal.ts
@@ -115,14 +115,14 @@ export class GraphDecimal {
     this._checkOutOfRange(this);
     const param = this._checkOutOfRange(n);
 
-    return this.value.lessThan(param);
+    return this.value.greaterThan(param);
   }
 
   gt (n: Decimal.Value | GraphDecimal): boolean {
     this._checkOutOfRange(this);
     const param = this._checkOutOfRange(n);
 
-    return this.value.lessThan(param);
+    return this.value.gt(param);
   }
 
   comparedTo (n: Decimal.Value | GraphDecimal): number {

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -269,11 +269,8 @@ export class Indexer {
         dbTx,
         eventEntityClass,
         {
-          where: {
-            block: { id: block.id },
-            eventName: UNKNOWN_EVENT_NAME
-          },
-          relations: ['block']
+          block: { id: block.id },
+          eventName: UNKNOWN_EVENT_NAME
         }
       );
 

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -100,7 +100,7 @@ export interface DatabaseInterface {
   updateSyncStatusCanonicalBlock (queryRunner: QueryRunner, blockHash: string, blockNumber: number, force?: boolean): Promise<SyncStatusInterface>;
   saveEvents (queryRunner: QueryRunner, events: DeepPartial<EventInterface>[]): Promise<void>;
   saveEventEntity (queryRunner: QueryRunner, entity: EventInterface): Promise<EventInterface>;
-  removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindManyOptions<Entity> | FindConditions<Entity>): Promise<void>;
+  removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindConditions<Entity>): Promise<void>;
   getContracts?: () => Promise<ContractInterface[]>
   saveContract?: (queryRunner: QueryRunner, contractAddress: string, kind: string, startingBlock: number) => Promise<ContractInterface>
 }


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

- Fixes for mismatch in entities after comparing with subgraph API.
- Save entity relations for PoolHourData, TokenDayData, TokenHourData and TickDayData.
- Fix limit for multiple entity queries.
- Entities matching till start block + 5000 (12374621).
- Save blocks in fill prefetch.
- Use delete query with condition for removing entities.