### PR TITLE
Implement order of processing events followed in subgraph

### DIFF
--- a/packages/erc20-watcher/src/cli/reset-cmds/state.ts
+++ b/packages/erc20-watcher/src/cli/reset-cmds/state.ts
@@ -13,6 +13,7 @@ import { Indexer } from '../../indexer';
 import { BlockProgress } from '../../entity/BlockProgress';
 import { Allowance } from '../../entity/Allowance';
 import { Balance } from '../../entity/Balance';
+import { Contract } from '../../entity/Contract';
 
 const log = debug('vulcanize:reset-state');
 
@@ -61,6 +62,7 @@ export const handler = async (argv: any): Promise<void> => {
     });
 
     await Promise.all(removeEntitiesPromise);
+    await db.removeEntities(dbTx, Contract, { startingBlock: MoreThan(argv.blockNumber) });
 
     if (syncStatus.latestIndexedBlockNumber > blockProgress.blockNumber) {
       await indexer.updateSyncStatusIndexedBlock(blockProgress.blockHash, blockProgress.blockNumber, true);

--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -296,7 +296,7 @@ export class Indexer {
     return this._baseIndexer.getEventsByFilter(blockHash, contract, name);
   }
 
-  async isWatchedContract (address : string): Promise<Contract | undefined> {
+  isWatchedContract (address : string): Contract | undefined {
     return this._baseIndexer.isWatchedContract(address);
   }
 

--- a/packages/uni-info-watcher/environments/local.toml
+++ b/packages/uni-info-watcher/environments/local.toml
@@ -41,3 +41,4 @@
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 1000
   eventsInBatch = 50
+  subgraphEventsOrder = true

--- a/packages/uni-info-watcher/src/cli/reset-cmds/state.ts
+++ b/packages/uni-info-watcher/src/cli/reset-cmds/state.ts
@@ -30,6 +30,7 @@ import { TokenDayData } from '../../entity/TokenDayData';
 import { TokenHourData } from '../../entity/TokenHourData';
 import { Transaction } from '../../entity/Transaction';
 import { UniswapDayData } from '../../entity/UniswapDayData';
+import { Contract } from '../../entity/Contract';
 
 const log = debug('vulcanize:reset-state');
 
@@ -106,6 +107,7 @@ export const handler = async (argv: any): Promise<void> => {
     });
 
     await Promise.all(removeEntitiesPromise);
+    await db.removeEntities(dbTx, Contract, { startingBlock: MoreThan(argv.blockNumber) });
 
     if (syncStatus.latestIndexedBlockNumber > blockProgress.blockNumber) {
       await indexer.updateSyncStatusIndexedBlock(blockProgress.blockHash, blockProgress.blockNumber, true);

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -45,6 +45,7 @@ import { BlockProgress } from './entity/BlockProgress';
 import { Block } from './events';
 import { SyncStatus } from './entity/SyncStatus';
 import { TickDayData } from './entity/TickDayData';
+import { Contract } from './entity/Contract';
 
 export class Database implements DatabaseInterface {
   _config: ConnectionOptions
@@ -588,6 +589,18 @@ export class Database implements DatabaseInterface {
     swap.blockNumber = block.number;
     swap.blockHash = block.hash;
     return repo.save(swap);
+  }
+
+  async getContracts (): Promise<Contract[]> {
+    const repo = this._conn.getRepository(Contract);
+
+    return this._baseDatabase.getContracts(repo);
+  }
+
+  async saveContract (queryRunner: QueryRunner, address: string, kind: string, startingBlock: number): Promise<Contract> {
+    const repo = queryRunner.manager.getRepository(Contract);
+
+    return this._baseDatabase.saveContract(repo, address, startingBlock, kind);
   }
 
   async createTransactionRunner (): Promise<QueryRunner> {

--- a/packages/uni-info-watcher/src/entity/Bundle.ts
+++ b/packages/uni-info-watcher/src/entity/Bundle.ts
@@ -2,10 +2,11 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column } from 'typeorm';
+import { Entity, PrimaryColumn, Column, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal } from '@vulcanize/util';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Bundle {
   @PrimaryColumn('varchar', { length: 1 })
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Burn.ts
+++ b/packages/uni-info-watcher/src/entity/Burn.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { bigintTransformer, graphDecimalTransformer, GraphDecimal } from '@vulcanize/util';
 
 import { Transaction } from './Transaction';
@@ -10,6 +10,7 @@ import { Pool } from './Pool';
 import { Token } from './Token';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Burn {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Contract.ts
+++ b/packages/uni-info-watcher/src/entity/Contract.ts
@@ -1,0 +1,25 @@
+//
+// Copyright 2021 Vulcanize, Inc.
+//
+
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+
+export const KIND_FACTORY = 'factory';
+export const KIND_POOL = 'pool';
+export const KIND_NFPM = 'nfpm';
+
+@Entity()
+@Index(['address'], { unique: true })
+export class Contract {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column('varchar', { length: 42 })
+  address!: string;
+
+  @Column('varchar', { length: 8 })
+  kind!: string;
+
+  @Column('integer')
+  startingBlock!: number;
+}

--- a/packages/uni-info-watcher/src/entity/Factory.ts
+++ b/packages/uni-info-watcher/src/entity/Factory.ts
@@ -2,10 +2,11 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, Column, PrimaryColumn } from 'typeorm';
+import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Factory {
   @PrimaryColumn('varchar', { length: 42 })
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Mint.ts
+++ b/packages/uni-info-watcher/src/entity/Mint.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Transaction } from './Transaction';
@@ -10,6 +10,7 @@ import { Pool } from './Pool';
 import { Token } from './Token';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Mint {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Pool.ts
+++ b/packages/uni-info-watcher/src/entity/Pool.ts
@@ -2,12 +2,13 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Token } from './Token';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Pool {
   @PrimaryColumn('varchar', { length: 42 })
   id!: string;

--- a/packages/uni-info-watcher/src/entity/PoolDayData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolDayData.ts
@@ -2,12 +2,13 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Pool } from './Pool';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class PoolDayData {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/PoolHourData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolHourData.ts
@@ -2,12 +2,13 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Pool } from './Pool';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class PoolHourData {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Position.ts
+++ b/packages/uni-info-watcher/src/entity/Position.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Pool } from './Pool';
@@ -12,6 +12,7 @@ import { Transaction } from './Transaction';
 import { ADDRESS_ZERO } from '../utils/constants';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Position {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/PositionSnapshot.ts
+++ b/packages/uni-info-watcher/src/entity/PositionSnapshot.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Pool } from './Pool';
@@ -11,6 +11,7 @@ import { ADDRESS_ZERO } from '../utils/constants';
 import { Position } from './Position';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class PositionSnapshot {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Swap.ts
+++ b/packages/uni-info-watcher/src/entity/Swap.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Transaction } from './Transaction';
@@ -10,6 +10,7 @@ import { Pool } from './Pool';
 import { Token } from './Token';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Swap {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Tick.ts
+++ b/packages/uni-info-watcher/src/entity/Tick.ts
@@ -2,12 +2,13 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Pool } from './Pool';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Tick {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/TickDayData.ts
+++ b/packages/uni-info-watcher/src/entity/TickDayData.ts
@@ -2,13 +2,14 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { bigintTransformer } from '@vulcanize/util';
 
 import { Pool } from './Pool';
 import { Tick } from './Tick';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class TickDayData {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Token.ts
+++ b/packages/uni-info-watcher/src/entity/Token.ts
@@ -2,12 +2,13 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToMany, JoinTable, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Pool } from './Pool';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Token {
   @PrimaryColumn('varchar', { length: 42 })
   id!: string;

--- a/packages/uni-info-watcher/src/entity/TokenDayData.ts
+++ b/packages/uni-info-watcher/src/entity/TokenDayData.ts
@@ -2,12 +2,13 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal } from '@vulcanize/util';
 
 import { Token } from './Token';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class TokenDayData {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/TokenHourData.ts
+++ b/packages/uni-info-watcher/src/entity/TokenHourData.ts
@@ -2,12 +2,13 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal } from '@vulcanize/util';
 
 import { Token } from './Token';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class TokenHourData {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Transaction.ts
+++ b/packages/uni-info-watcher/src/entity/Transaction.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column, OneToMany } from 'typeorm';
+import { Entity, PrimaryColumn, Column, OneToMany, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 import { Mint } from './Mint';
@@ -10,6 +10,7 @@ import { Burn } from './Burn';
 import { Swap } from './Swap';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class Transaction {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/UniswapDayData.ts
+++ b/packages/uni-info-watcher/src/entity/UniswapDayData.ts
@@ -2,10 +2,11 @@
 // Copyright 2021 Vulcanize, Inc.
 //
 
-import { Entity, PrimaryColumn, Column } from 'typeorm';
+import { Entity, PrimaryColumn, Column, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
 
 @Entity()
+@Index(['id', 'blockNumber'])
 export class UniswapDayData {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -1216,7 +1216,11 @@ export class Indexer implements IndexerInterface {
     }
 
     // Temp fix from Subgraph mapping code.
-    if (utils.getAddress(position.pool.id) === utils.getAddress('0x8fe8d9bb8eeba3ed688069c3d6b556c9ca258248')) {
+    // if (utils.getAddress(position.pool.id) === utils.getAddress('0x8fe8d9bb8eeba3ed688069c3d6b556c9ca258248')) {
+    //   return;
+    // }
+    // For the above scenario position.pool is null which is computed in this._getPosition.
+    if (!position.pool) {
       return;
     }
 
@@ -1261,7 +1265,11 @@ export class Indexer implements IndexerInterface {
     }
 
     // Temp fix from Subgraph mapping code.
-    if (utils.getAddress(position.pool.id) === utils.getAddress('0x8fe8d9bb8eeba3ed688069c3d6b556c9ca258248')) {
+    // if (utils.getAddress(position.pool.id) === utils.getAddress('0x8fe8d9bb8eeba3ed688069c3d6b556c9ca258248')) {
+    //   return;
+    // }
+    // For the above scenario position.pool is null which is computed in this._getPosition.
+    if (!position.pool) {
       return;
     }
 
@@ -1305,7 +1313,11 @@ export class Indexer implements IndexerInterface {
     }
 
     // Temp fix from Subgraph mapping code.
-    if (utils.getAddress(position.pool.id) === utils.getAddress('0x8fe8d9bb8eeba3ed688069c3d6b556c9ca258248')) {
+    // if (utils.getAddress(position.pool.id) === utils.getAddress('0x8fe8d9bb8eeba3ed688069c3d6b556c9ca258248')) {
+    //   return;
+    // }
+    // For the above scenario position.pool is null which is computed in this._getPosition.
+    if (!position.pool) {
       return;
     }
 

--- a/packages/uni-info-watcher/src/job-runner.ts
+++ b/packages/uni-info-watcher/src/job-runner.ts
@@ -131,6 +131,9 @@ export const main = async (): Promise<any> => {
   await jobQueue.start();
 
   const indexer = new Indexer(db, uniClient, erc20Client, ethClient, postgraphileClient, ethProvider, jobQueue, mode);
+  await indexer.init();
+
+  await indexer.addContracts();
 
   const jobRunner = new JobRunner(jobQueueConfig, indexer, jobQueue);
   await jobRunner.start();

--- a/packages/uni-info-watcher/src/utils/constants.ts
+++ b/packages/uni-info-watcher/src/utils/constants.ts
@@ -4,4 +4,22 @@
 
 import { utils } from 'ethers';
 
+import { KIND_FACTORY, KIND_NFPM } from '../entity/Contract';
+
 export const ADDRESS_ZERO = utils.getAddress('0x0000000000000000000000000000000000000000');
+
+export const FACTORY_ADDRESS = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
+export const NFPM_ADDRESS = '0xC36442b4a4522E871399CD717aBDD847Ab11FE88';
+
+export const WATCHED_CONTRACTS = [
+  {
+    kind: KIND_FACTORY,
+    address: FACTORY_ADDRESS,
+    startingBlock: 12369621
+  },
+  {
+    kind: KIND_NFPM,
+    address: NFPM_ADDRESS,
+    startingBlock: 12369651
+  }
+];

--- a/packages/uni-info-watcher/src/utils/index.ts
+++ b/packages/uni-info-watcher/src/utils/index.ts
@@ -4,12 +4,15 @@
 
 import { BigNumber, utils } from 'ethers';
 import { QueryRunner } from 'typeorm';
+import assert from 'assert';
 
 import { GraphDecimal } from '@vulcanize/util';
 
 import { Transaction as TransactionEntity } from '../entity/Transaction';
 import { Database } from '../database';
 import { Block, Transaction } from '../events';
+import { Factory } from '../entity/Factory';
+import { FACTORY_ADDRESS } from './constants';
 
 export const exponentToBigDecimal = (decimals: bigint): GraphDecimal => {
   let bd = new GraphDecimal(1);
@@ -73,4 +76,17 @@ export const bigDecimalExponated = (value: GraphDecimal, power: bigint): GraphDe
   }
 
   return result;
+};
+
+export const loadFactory = async (db: Database, dbTx: QueryRunner, block: Block, isDemo: boolean): Promise<Factory> => {
+  let factory = await db.getFactory(dbTx, { blockHash: block.hash, id: FACTORY_ADDRESS });
+
+  if (isDemo) {
+    // Currently fetching first factory in database as only one exists.
+    [factory] = await db.getModelEntities(dbTx, Factory, { hash: block.hash }, {}, { limit: 1 });
+  }
+
+  assert(factory);
+
+  return factory;
 };

--- a/packages/uni-info-watcher/src/utils/interval-updates.ts
+++ b/packages/uni-info-watcher/src/utils/interval-updates.ts
@@ -6,8 +6,8 @@ import assert from 'assert';
 import { BigNumber, utils } from 'ethers';
 import { QueryRunner } from 'typeorm';
 
+import { loadFactory } from './index';
 import { Database } from '../database';
-import { Factory } from '../entity/Factory';
 import { PoolDayData } from '../entity/PoolDayData';
 import { PoolHourData } from '../entity/PoolHourData';
 import { Tick } from '../entity/Tick';
@@ -23,12 +23,18 @@ import { Block } from '../events';
  * @param db
  * @param event
  */
-export const updateUniswapDayData = async (db: Database, dbTx: QueryRunner, event: { contractAddress: string, block: Block }): Promise<UniswapDayData> => {
+export const updateUniswapDayData = async (
+  db: Database,
+  dbTx: QueryRunner,
+  event: {
+    contractAddress: string,
+    block: Block
+  },
+  isDemo: boolean
+): Promise<UniswapDayData> => {
   const { block } = event;
 
-  // TODO: In subgraph factory is fetched by hardcoded factory address.
-  // Currently fetching first factory in database as only one exists.
-  const [factory] = await db.getModelEntities(dbTx, Factory, { hash: block.hash }, {}, { limit: 1 });
+  const factory = await loadFactory(db, dbTx, block, isDemo);
 
   const dayID = Math.floor(block.timestamp / 86400); // Rounded.
   const dayStartTimestamp = dayID * 86400;

--- a/packages/uni-watcher/src/cli/reset-cmds/state.ts
+++ b/packages/uni-watcher/src/cli/reset-cmds/state.ts
@@ -11,6 +11,7 @@ import { getConfig, getResetConfig, JobQueue, resetJobs } from '@vulcanize/util'
 import { Database } from '../../database';
 import { Indexer } from '../../indexer';
 import { BlockProgress } from '../../entity/BlockProgress';
+import { Contract } from '../../entity/Contract';
 
 const log = debug('vulcanize:reset-state');
 
@@ -55,6 +56,7 @@ export const handler = async (argv: any): Promise<void> => {
 
   try {
     await db.removeEntities(dbTx, BlockProgress, { blockNumber: MoreThan(blockProgress.blockNumber) });
+    await db.removeEntities(dbTx, Contract, { startingBlock: MoreThan(argv.blockNumber) });
 
     if (syncStatus.latestIndexedBlockNumber > blockProgress.blockNumber) {
       await indexer.updateSyncStatusIndexedBlock(blockProgress.blockHash, blockProgress.blockNumber, true);

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -343,7 +343,7 @@ export class Indexer implements IndexerInterface {
     return this._baseIndexer.getEventsByFilter(blockHash, contract, name);
   }
 
-  async isWatchedContract (address: string): Promise<Contract | undefined> {
+  isWatchedContract (address: string): Contract | undefined {
     return this._baseIndexer.isWatchedContract(address);
   }
 

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -23,6 +23,7 @@ export interface JobQueueConfig {
   jobDelayInMilliSecs?: number;
   eventsInBatch: number;
   lazyUpdateBlockProgress?: boolean;
+  subgraphEventsOrder: boolean;
 }
 
 interface ServerConfig {

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -334,7 +334,7 @@ export class Indexer {
     return this._db.getEventsInRange(fromBlockNumber, toBlockNumber);
   }
 
-  async isWatchedContract (address : string): Promise<ContractInterface | undefined> {
+  isWatchedContract (address : string): ContractInterface | undefined {
     return this._watchedContracts[address];
   }
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -358,6 +358,8 @@ export class JobRunner {
           Math.max(block.lastProcessedEventIndex + 1, dbEvent.index)
         );
       }
+
+      dbEvents = dbEvents.concat(unwatchedContractEvents);
     }
 
     console.timeEnd('time:job-runner#_processEvents-processing_events');

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -258,7 +258,7 @@ export class JobRunner {
     const events = this._blockEventsMap.get(block.blockHash);
     assert(events);
 
-    const dbEvents = events.map(event => {
+    let dbEvents = events.map(event => {
       event.block = block;
       return event as EventInterface;
     });
@@ -268,6 +268,24 @@ export class JobRunner {
     }
 
     console.time('time:job-runner#_processEvents-processing_events');
+    const { subgraphEventsOrder = false } = this._jobQueueConfig;
+    const unwatchedContractEvents: EventInterface[] = [];
+
+    if (subgraphEventsOrder) {
+      // Processing events out of order causes issue with restarts/kill at arbitrary times.
+      // Events of contract, added to watch in processing an event, may not be processed at end after restart/kill.
+      const watchedContractEvents: EventInterface[] = [];
+
+      dbEvents.forEach(dbEvent => {
+        if (this._indexer.isWatchedContract(dbEvent.contract)) {
+          watchedContractEvents.push(dbEvent);
+        } else {
+          unwatchedContractEvents.push(dbEvent);
+        }
+      });
+
+      dbEvents = watchedContractEvents;
+    }
 
     for (let dbEvent of dbEvents) {
       if (dbEvent.index <= block.lastProcessedEventIndex) {
@@ -278,24 +296,20 @@ export class JobRunner {
       const eventIndex = dbEvent.index;
       // log(`Processing event ${event.id} index ${eventIndex}`);
 
-      // Check if previous event in block has been processed exactly before this and abort if not.
-      if (eventIndex > 0) { // Skip the first event in the block.
-        const prevIndex = eventIndex - 1;
+      if (!subgraphEventsOrder) {
+        // Check if previous event in block has been processed exactly before this and abort if not.
+        // Skip check incase of subgraphEventsOrder.
+        if (eventIndex > 0) { // Skip the first event in the block.
+          const prevIndex = eventIndex - 1;
 
-        if (prevIndex !== block.lastProcessedEventIndex) {
-          throw new Error(`Events received out of order for block number ${block.blockNumber} hash ${block.blockHash},` +
-          ` prev event index ${prevIndex}, got event index ${dbEvent.index} and lastProcessedEventIndex ${block.lastProcessedEventIndex}, aborting`);
+          if (prevIndex !== block.lastProcessedEventIndex) {
+            throw new Error(`Events received out of order for block number ${block.blockNumber} hash ${block.blockHash},` +
+            ` prev event index ${prevIndex}, got event index ${dbEvent.index} and lastProcessedEventIndex ${block.lastProcessedEventIndex}, aborting`);
+          }
         }
       }
 
-      let watchedContract;
-
-      if (!this._indexer.isWatchedContract) {
-        // uni-info-watcher indexer doesn't have watched contracts implementation.
-        watchedContract = true;
-      } else {
-        watchedContract = await this._indexer.isWatchedContract(dbEvent.contract);
-      }
+      const watchedContract = this._indexer.isWatchedContract(dbEvent.contract);
 
       if (watchedContract) {
         // We might not have parsed this event yet. This can happen if the contract was added
@@ -325,6 +339,24 @@ export class JobRunner {
         }
       } else {
         block = await this._indexer.updateBlockProgress(block, dbEvent.index);
+      }
+    }
+
+    if (subgraphEventsOrder) {
+      // Process events from contracts not watched initially.
+      for (const dbEvent of unwatchedContractEvents) {
+        const watchedContract = this._indexer.isWatchedContract(dbEvent.contract);
+
+        if (watchedContract) {
+          // Events of contract added in same block might be processed multiple times.
+          // This is because there is no check for lastProcessedEventIndex against these events.
+          await this._indexer.processEvent(dbEvent);
+        }
+
+        block = await this._indexer.updateBlockProgress(
+          block,
+          Math.max(block.lastProcessedEventIndex + 1, dbEvent.index)
+        );
       }
     }
 

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -70,7 +70,7 @@ export interface IndexerInterface {
   saveEvents (dbEvents: EventInterface[]): Promise<void>;
   processEvent (event: EventInterface): Promise<void>;
   parseEventNameAndArgs?: (kind: string, logObj: any) => any;
-  isWatchedContract?: (address: string) => Promise<ContractInterface | undefined>;
+  isWatchedContract: (address: string) => ContractInterface | undefined;
   cacheContract?: (contract: ContractInterface) => void;
 }
 
@@ -101,6 +101,6 @@ export interface DatabaseInterface {
   saveEvents (queryRunner: QueryRunner, events: DeepPartial<EventInterface>[]): Promise<void>;
   saveEventEntity (queryRunner: QueryRunner, entity: EventInterface): Promise<EventInterface>;
   removeEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindConditions<Entity>): Promise<void>;
-  getContracts?: () => Promise<ContractInterface[]>
-  saveContract?: (queryRunner: QueryRunner, contractAddress: string, kind: string, startingBlock: number) => Promise<ContractInterface>
+  getContracts: () => Promise<ContractInterface[]>
+  saveContract: (queryRunner: QueryRunner, contractAddress: string, kind: string, startingBlock: number) => Promise<ContractInterface>
 }


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

- In subgraph, events from datasource template created in the same block are processed after all other events.
- Implemented the same in uni-info-watcher using a flag `jobQueue.subgraphEventsOrder`.
- Fix NFPM event related to pool skipped in mapping code.
- Fetch Factory entity by id similar to subgraph mapping code.
- Improve query to fetch multiple entities.