### PR TITLE
Implement separate queries for entity relations

### DIFF
--- a/packages/uni-info-watcher/docs/analysis/queries/queries.md
+++ b/packages/uni-info-watcher/docs/analysis/queries/queries.md
@@ -15,6 +15,7 @@
         date
         volumeUSD
         tvlUSD
+        feesUSD
       }
     }
     ```

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -137,7 +137,6 @@ export class Database implements DatabaseInterface {
 
     const findOptions = {
       where: whereOptions,
-      relations: ['whitelistPools', 'whitelistPools.token0', 'whitelistPools.token1'],
       order: {
         blockNumber: 'DESC'
       }
@@ -147,6 +146,22 @@ export class Database implements DatabaseInterface {
 
     if (!entity && findOptions.where.blockHash) {
       entity = await this._baseDatabase.getPrevEntityVersion(queryRunner, repo, findOptions);
+    }
+
+    if (entity) {
+      [entity] = await this._baseDatabase.loadRelations(
+        queryRunner,
+        { hash: blockHash, number: blockNumber },
+        [
+          {
+            entity: Pool,
+            type: 'many-to-many',
+            property: 'whitelistPools',
+            field: 'pool'
+          }
+        ],
+        [entity]
+      );
     }
 
     return entity;
@@ -180,7 +195,6 @@ export class Database implements DatabaseInterface {
 
     const findOptions = {
       where: whereOptions,
-      relations: ['token0', 'token1'],
       order: {
         blockNumber: 'DESC'
       }
@@ -190,6 +204,28 @@ export class Database implements DatabaseInterface {
 
     if (!entity && findOptions.where.blockHash) {
       entity = await this._baseDatabase.getPrevEntityVersion(queryRunner, repo, findOptions);
+    }
+
+    if (entity) {
+      [entity] = await this._baseDatabase.loadRelations(
+        queryRunner,
+        { hash: blockHash, number: blockNumber },
+        [
+          {
+            entity: Token,
+            type: 'one-to-one',
+            property: 'token0',
+            field: 'token0Id'
+          },
+          {
+            entity: Token,
+            type: 'one-to-one',
+            property: 'token1',
+            field: 'token1Id'
+          }
+        ],
+        [entity]
+      );
     }
 
     return entity;
@@ -224,7 +260,6 @@ export class Database implements DatabaseInterface {
 
       const findOptions = {
         where: whereOptions,
-        relations: ['pool', 'token0', 'token1', 'tickLower', 'tickUpper', 'transaction'],
         order: {
           blockNumber: 'DESC'
         }
@@ -234,6 +269,52 @@ export class Database implements DatabaseInterface {
 
       if (!entity && findOptions.where.blockHash) {
         entity = await this._baseDatabase.getPrevEntityVersion(queryRunner, repo, findOptions);
+      }
+
+      if (entity) {
+        [entity] = await this._baseDatabase.loadRelations(
+          queryRunner,
+          { hash: blockHash },
+          [
+            {
+              entity: Pool,
+              type: 'one-to-one',
+              property: 'pool',
+              field: 'poolId'
+            },
+            {
+              entity: Token,
+              type: 'one-to-one',
+              property: 'token0',
+              field: 'token0Id'
+            },
+            {
+              entity: Token,
+              type: 'one-to-one',
+              property: 'token1',
+              field: 'token1Id'
+            },
+            {
+              entity: Tick,
+              type: 'one-to-one',
+              property: 'tickLower',
+              field: 'tickLowerId'
+            },
+            {
+              entity: Tick,
+              type: 'one-to-one',
+              property: 'tickUpper',
+              field: 'tickUpperId'
+            },
+            {
+              entity: Transaction,
+              type: 'one-to-one',
+              property: 'transaction',
+              field: 'transactionId'
+            }
+          ],
+          [entity]
+        );
       }
     } finally {
       await queryRunner.release();
@@ -252,7 +333,6 @@ export class Database implements DatabaseInterface {
 
     const findOptions = {
       where: whereOptions,
-      relations: ['pool'],
       order: {
         blockNumber: 'DESC'
       }
@@ -262,6 +342,22 @@ export class Database implements DatabaseInterface {
 
     if (!entity && findOptions.where.blockHash) {
       entity = await this._baseDatabase.getPrevEntityVersion(queryRunner, repo, findOptions);
+    }
+
+    if (entity) {
+      [entity] = await this._baseDatabase.loadRelations(
+        queryRunner,
+        { hash: blockHash },
+        [
+          {
+            entity: Pool,
+            type: 'one-to-one',
+            property: 'pool',
+            field: 'poolId'
+          }
+        ],
+        [entity]
+      );
     }
 
     return entity;
@@ -293,14 +389,29 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      },
-      relations: ['pool']
+      }
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<PoolDayData>);
 
     if (!entity && findOptions.where.blockHash) {
       entity = await this._baseDatabase.getPrevEntityVersion(queryRunner, repo, findOptions);
+    }
+
+    if (entity) {
+      [entity] = await this._baseDatabase.loadRelations(
+        queryRunner,
+        { hash: blockHash },
+        [
+          {
+            entity: Pool,
+            type: 'one-to-one',
+            property: 'pool',
+            field: 'poolId'
+          }
+        ],
+        [entity]
+      );
     }
 
     return entity;
@@ -318,14 +429,29 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      },
-      relations: ['pool']
+      }
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<PoolHourData>);
 
     if (!entity && findOptions.where.blockHash) {
       entity = await this._baseDatabase.getPrevEntityVersion(queryRunner, repo, findOptions);
+    }
+
+    if (entity) {
+      [entity] = await this._baseDatabase.loadRelations(
+        queryRunner,
+        { hash: blockHash },
+        [
+          {
+            entity: Pool,
+            type: 'one-to-one',
+            property: 'pool',
+            field: 'poolId'
+          }
+        ],
+        [entity]
+      );
     }
 
     return entity;
@@ -367,14 +493,29 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      },
-      relations: ['token']
+      }
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<TokenDayData>);
 
     if (!entity && findOptions.where.blockHash) {
       entity = await this._baseDatabase.getPrevEntityVersion(queryRunner, repo, findOptions);
+    }
+
+    if (entity) {
+      [entity] = await this._baseDatabase.loadRelations(
+        queryRunner,
+        { hash: blockHash },
+        [
+          {
+            entity: Token,
+            type: 'one-to-one',
+            property: 'token',
+            field: 'tokenId'
+          }
+        ],
+        [entity]
+      );
     }
 
     return entity;
@@ -392,14 +533,29 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      },
-      relations: ['token']
+      }
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<TokenHourData>);
 
     if (!entity && findOptions.where.blockHash) {
       entity = await this._baseDatabase.getPrevEntityVersion(queryRunner, repo, findOptions);
+    }
+
+    if (entity) {
+      [entity] = await this._baseDatabase.loadRelations(
+        queryRunner,
+        { hash: blockHash },
+        [
+          {
+            entity: Token,
+            type: 'one-to-one',
+            property: 'token',
+            field: 'tokenId'
+          }
+        ],
+        [entity]
+      );
     }
 
     return entity;
@@ -417,14 +573,35 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      },
-      relations: ['tick', 'pool']
+      }
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<TickDayData>);
 
     if (!entity && findOptions.where.blockHash) {
       entity = await this._baseDatabase.getPrevEntityVersion(queryRunner, repo, findOptions);
+    }
+
+    if (entity) {
+      [entity] = await this._baseDatabase.loadRelations(
+        queryRunner,
+        { hash: blockHash },
+        [
+          {
+            entity: Tick,
+            type: 'one-to-one',
+            property: 'tick',
+            field: 'tickId'
+          },
+          {
+            entity: Pool,
+            type: 'one-to-one',
+            property: 'pool',
+            field: 'PoolId'
+          }
+        ],
+        [entity]
+      );
     }
 
     return entity;

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -139,7 +139,8 @@ export class Database implements DatabaseInterface {
       where: whereOptions,
       order: {
         blockNumber: 'DESC'
-      }
+      },
+      relations: ['whitelistPools']
     };
 
     let entity = await repo.findOne(findOptions as FindOneOptions<Token>);
@@ -152,6 +153,7 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash, number: blockNumber },
+        {},
         [
           {
             entity: Pool,
@@ -210,6 +212,7 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash, number: blockNumber },
+        {},
         [
           {
             entity: Token,
@@ -275,6 +278,7 @@ export class Database implements DatabaseInterface {
         [entity] = await this._baseDatabase.loadRelations(
           queryRunner,
           { hash: blockHash },
+          {},
           [
             {
               entity: Pool,
@@ -348,6 +352,7 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
+        {},
         [
           {
             entity: Pool,
@@ -402,6 +407,7 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
+        {},
         [
           {
             entity: Pool,
@@ -442,6 +448,7 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
+        {},
         [
           {
             entity: Pool,
@@ -506,6 +513,7 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
+        {},
         [
           {
             entity: Token,
@@ -546,6 +554,7 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
+        {},
         [
           {
             entity: Token,
@@ -586,6 +595,7 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
+        {},
         [
           {
             entity: Tick,

--- a/packages/uni-info-watcher/src/entity/Burn.ts
+++ b/packages/uni-info-watcher/src/entity/Burn.ts
@@ -11,6 +11,7 @@ import { Token } from './Token';
 
 @Entity()
 @Index(['id', 'blockNumber'])
+@Index(['transactionId'])
 export class Burn {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Burn.ts
+++ b/packages/uni-info-watcher/src/entity/Burn.ts
@@ -22,11 +22,17 @@ export class Burn {
   @Column('integer')
   blockNumber!: number;
 
+  @Column('varchar', { nullable: true })
+  transactionId!: string;
+
   @ManyToOne(() => Transaction, transaction => transaction.burns, { onDelete: 'CASCADE' })
   transaction!: Transaction
 
   @Column('numeric', { transformer: bigintTransformer })
   timestamp!: bigint;
+
+  @Column('varchar', { length: 42, nullable: true })
+  poolId!: string;
 
   @ManyToOne(() => Pool, { onDelete: 'CASCADE' })
   pool!: Pool

--- a/packages/uni-info-watcher/src/entity/Mint.ts
+++ b/packages/uni-info-watcher/src/entity/Mint.ts
@@ -22,11 +22,17 @@ export class Mint {
   @Column('integer')
   blockNumber!: number;
 
+  @Column('varchar', { nullable: true })
+  transactionId!: string;
+
   @ManyToOne(() => Transaction, transaction => transaction.mints, { onDelete: 'CASCADE' })
   transaction!: Transaction
 
   @Column('numeric', { transformer: bigintTransformer })
   timestamp!: bigint;
+
+  @Column('varchar', { length: 42, nullable: true })
+  poolId!: string;
 
   @ManyToOne(() => Pool, { onDelete: 'CASCADE' })
   pool!: Pool

--- a/packages/uni-info-watcher/src/entity/Mint.ts
+++ b/packages/uni-info-watcher/src/entity/Mint.ts
@@ -11,6 +11,7 @@ import { Token } from './Token';
 
 @Entity()
 @Index(['id', 'blockNumber'])
+@Index(['transactionId'])
 export class Mint {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Pool.ts
+++ b/packages/uni-info-watcher/src/entity/Pool.ts
@@ -20,13 +20,13 @@ export class Pool {
   @Column('integer')
   blockNumber!: number;
 
-  @Column('varchar', { length: 42, nullable: true })
+  @Column('varchar', { length: 42, nullable: true, name: 'token0_id' })
   token0Id!: string;
 
   @ManyToOne(() => Token, { onDelete: 'CASCADE' })
   token0!: Token;
 
-  @Column('varchar', { length: 42, nullable: true })
+  @Column('varchar', { length: 42, nullable: true, name: 'token1_id' })
   token1Id!: string;
 
   @ManyToOne(() => Token, { onDelete: 'CASCADE' })

--- a/packages/uni-info-watcher/src/entity/Pool.ts
+++ b/packages/uni-info-watcher/src/entity/Pool.ts
@@ -20,8 +20,14 @@ export class Pool {
   @Column('integer')
   blockNumber!: number;
 
+  @Column('varchar', { length: 42, nullable: true })
+  token0Id!: string;
+
   @ManyToOne(() => Token, { onDelete: 'CASCADE' })
   token0!: Token;
+
+  @Column('varchar', { length: 42, nullable: true })
+  token1Id!: string;
 
   @ManyToOne(() => Token, { onDelete: 'CASCADE' })
   token1!: Token;

--- a/packages/uni-info-watcher/src/entity/PoolDayData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolDayData.ts
@@ -23,6 +23,9 @@ export class PoolDayData {
   @Column('integer')
   date!: number;
 
+  @Column('varchar', { length: 42, nullable: true })
+  poolId!: string;
+
   @ManyToOne(() => Pool, { onDelete: 'CASCADE' })
   pool!: Pool;
 

--- a/packages/uni-info-watcher/src/entity/PoolDayData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolDayData.ts
@@ -9,6 +9,7 @@ import { Pool } from './Pool';
 
 @Entity()
 @Index(['id', 'blockNumber'])
+@Index(['date', 'poolId'])
 export class PoolDayData {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/PoolHourData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolHourData.ts
@@ -23,6 +23,9 @@ export class PoolHourData {
   @Column('integer')
   periodStartUnix!: number;
 
+  @Column('varchar', { length: 42, nullable: true })
+  poolId!: string;
+
   @ManyToOne(() => Pool, { onDelete: 'CASCADE' })
   pool!: Pool;
 

--- a/packages/uni-info-watcher/src/entity/Position.ts
+++ b/packages/uni-info-watcher/src/entity/Position.ts
@@ -54,20 +54,38 @@ export class Position {
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   collectedFeesToken1!: GraphDecimal
 
+  @Column('varchar', { length: 42, nullable: true })
+  poolId!: string;
+
   @ManyToOne(() => Pool, { onDelete: 'CASCADE' })
   pool!: Pool
+
+  @Column('varchar', { length: 42, nullable: true })
+  token0Id!: string;
 
   @ManyToOne(() => Token)
   token0!: Token
 
+  @Column('varchar', { length: 42, nullable: true })
+  token1Id!: string;
+
   @ManyToOne(() => Token)
   token1!: Token
+
+  @Column('varchar', { nullable: true })
+  tickLowerId!: string;
 
   @ManyToOne(() => Tick)
   tickLower!: Tick
 
+  @Column('varchar', { nullable: true })
+  tickUpperId!: string;
+
   @ManyToOne(() => Tick)
   tickUpper!: Tick
+
+  @Column('varchar', { nullable: true })
+  transactionId!: string;
 
   @ManyToOne(() => Transaction)
   transaction!: Transaction

--- a/packages/uni-info-watcher/src/entity/Position.ts
+++ b/packages/uni-info-watcher/src/entity/Position.ts
@@ -60,13 +60,13 @@ export class Position {
   @ManyToOne(() => Pool, { onDelete: 'CASCADE' })
   pool!: Pool
 
-  @Column('varchar', { length: 42, nullable: true })
+  @Column('varchar', { length: 42, nullable: true, name: 'token0_id' })
   token0Id!: string;
 
   @ManyToOne(() => Token)
   token0!: Token
 
-  @Column('varchar', { length: 42, nullable: true })
+  @Column('varchar', { length: 42, nullable: true, name: 'token1_id' })
   token1Id!: string;
 
   @ManyToOne(() => Token)

--- a/packages/uni-info-watcher/src/entity/Swap.ts
+++ b/packages/uni-info-watcher/src/entity/Swap.ts
@@ -22,11 +22,17 @@ export class Swap {
   @Column('integer')
   blockNumber!: number;
 
+  @Column('varchar', { nullable: true })
+  transactionId!: string;
+
   @ManyToOne(() => Transaction, transaction => transaction.swaps, { onDelete: 'CASCADE' })
   transaction!: Transaction
 
   @Column('numeric', { transformer: bigintTransformer })
   timestamp!: bigint;
+
+  @Column('varchar', { length: 42, nullable: true })
+  poolId!: string;
 
   @ManyToOne(() => Pool, { onDelete: 'CASCADE' })
   pool!: Pool

--- a/packages/uni-info-watcher/src/entity/Swap.ts
+++ b/packages/uni-info-watcher/src/entity/Swap.ts
@@ -11,6 +11,7 @@ import { Token } from './Token';
 
 @Entity()
 @Index(['id', 'blockNumber'])
+@Index(['transactionId'])
 export class Swap {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Tick.ts
+++ b/packages/uni-info-watcher/src/entity/Tick.ts
@@ -23,6 +23,9 @@ export class Tick {
   @Column('numeric', { transformer: bigintTransformer })
   tickIdx!: bigint;
 
+  @Column('varchar', { length: 42, nullable: true })
+  poolId!: string;
+
   @ManyToOne(() => Pool, { onDelete: 'CASCADE' })
   pool!: Pool
 

--- a/packages/uni-info-watcher/src/entity/TickDayData.ts
+++ b/packages/uni-info-watcher/src/entity/TickDayData.ts
@@ -24,8 +24,14 @@ export class TickDayData {
   @Column('integer')
   date!: number
 
+  @Column('varchar', { length: 42, nullable: true })
+  poolId!: string;
+
   @ManyToOne(() => Pool, { onDelete: 'CASCADE' })
   pool!: Pool;
+
+  @Column('varchar', { nullable: true })
+  tickId!: string;
 
   @ManyToOne(() => Tick, { onDelete: 'CASCADE' })
   tick!: Tick

--- a/packages/uni-info-watcher/src/entity/TokenDayData.ts
+++ b/packages/uni-info-watcher/src/entity/TokenDayData.ts
@@ -23,6 +23,9 @@ export class TokenDayData {
   @Column('integer')
   date!: number
 
+  @Column('varchar', { length: 42, nullable: true })
+  tokenId!: string;
+
   @ManyToOne(() => Token, { onDelete: 'CASCADE' })
   token!: Token
 

--- a/packages/uni-info-watcher/src/entity/TokenDayData.ts
+++ b/packages/uni-info-watcher/src/entity/TokenDayData.ts
@@ -9,6 +9,7 @@ import { Token } from './Token';
 
 @Entity()
 @Index(['id', 'blockNumber'])
+@Index(['date', 'tokenId'])
 export class TokenDayData {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/TokenHourData.ts
+++ b/packages/uni-info-watcher/src/entity/TokenHourData.ts
@@ -23,6 +23,9 @@ export class TokenHourData {
   @Column('integer')
   periodStartUnix!: number
 
+  @Column('varchar', { length: 42, nullable: true })
+  tokenId!: string;
+
   @ManyToOne(() => Token, { onDelete: 'CASCADE' })
   token!: Token
 

--- a/packages/uni-info-watcher/src/entity/TokenHourData.ts
+++ b/packages/uni-info-watcher/src/entity/TokenHourData.ts
@@ -9,6 +9,7 @@ import { Token } from './Token';
 
 @Entity()
 @Index(['id', 'blockNumber'])
+@Index(['periodStartUnix', 'tokenId'])
 export class TokenHourData {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -290,11 +290,6 @@ export class Indexer implements IndexerInterface {
         return acc;
       }, {});
 
-      if (!queryOptions.orderBy) {
-        // Default order by id.
-        queryOptions.orderBy = 'id';
-      }
-
       res = await this._db.getModelEntities(dbTx, entity, block, where, queryOptions, relations);
       dbTx.commitTransaction();
     } catch (error) {

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -4,7 +4,7 @@
 
 import assert from 'assert';
 import debug from 'debug';
-import { DeepPartial, FindConditions, FindManyOptions, QueryRunner } from 'typeorm';
+import { DeepPartial, FindConditions, FindManyOptions, FindOneOptions, LessThan, MoreThan, QueryRunner } from 'typeorm';
 import JSONbig from 'json-bigint';
 import { providers, utils, BigNumber } from 'ethers';
 
@@ -160,20 +160,28 @@ export class Indexer implements IndexerInterface {
 
   async getBlockEntities (where: { [key: string]: any } = {}, queryOptions: QueryOptions): Promise<any> {
     if (where.timestamp_gt) {
-      where.blockTimestamp_gt = where.timestamp_gt;
+      where.blockTimestamp = MoreThan(where.timestamp_gt);
       delete where.timestamp_gt;
     }
 
     if (where.timestamp_lt) {
-      where.blockTimestamp_lt = where.timestamp_lt;
+      where.blockTimestamp = LessThan(where.timestamp_lt);
       delete where.timestamp_lt;
     }
 
+    const order: FindOneOptions['order'] = {};
+
     if (queryOptions.orderBy === 'timestamp') {
-      queryOptions.orderBy = 'blockTimestamp';
+      order.blockTimestamp = queryOptions.orderDirection === 'desc' ? 'DESC' : 'ASC';
     }
 
-    const blocks = await this.getEntities(BlockProgress, {}, where, queryOptions);
+    const blocks = await this.getBlockProgressEntities(
+      where,
+      {
+        order,
+        take: queryOptions.limit
+      }
+    );
 
     return blocks.map(block => ({
       timestamp: block.blockTimestamp,

--- a/packages/uni-info-watcher/src/resolvers.ts
+++ b/packages/uni-info-watcher/src/resolvers.ts
@@ -249,7 +249,20 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
       tokens: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('tokens', orderBy, orderDirection, where);
 
-        return indexer.getEntities(Token, block, where, { limit: first, orderBy, orderDirection }, ['token.whitelistPools']);
+        return indexer.getEntities(
+          Token,
+          block,
+          where,
+          { limit: first, orderBy, orderDirection },
+          [
+            {
+              entity: Pool,
+              type: 'many-to-many',
+              property: 'whitelistPools',
+              field: 'pool'
+            }
+          ]
+        );
       },
 
       tokenDayDatas: async (_: any, { block = {}, first, skip, orderBy, orderDirection, where }: { block: BlockHeight, first: number, skip: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {

--- a/packages/uni-info-watcher/src/resolvers.ts
+++ b/packages/uni-info-watcher/src/resolvers.ts
@@ -77,7 +77,40 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
       burns: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('burns', first, orderBy, orderDirection, where);
 
-        return indexer.getEntities(Burn, block, where, { limit: first, orderBy, orderDirection }, ['burn.pool', 'burn.transaction', 'pool.token0', 'pool.token1']);
+        return indexer.getEntities(
+          Burn,
+          block,
+          where,
+          { limit: first, orderBy, orderDirection },
+          [
+            {
+              entity: Pool,
+              type: 'one-to-one',
+              property: 'pool',
+              field: 'poolId',
+              childRelations: [
+                {
+                  entity: Token,
+                  type: 'one-to-one',
+                  property: 'token0',
+                  field: 'token0Id'
+                },
+                {
+                  entity: Token,
+                  type: 'one-to-one',
+                  property: 'token1',
+                  field: 'token1Id'
+                }
+              ]
+            },
+            {
+              entity: Transaction,
+              type: 'one-to-one',
+              property: 'transaction',
+              field: 'transactionId'
+            }
+          ]
+        );
       },
 
       factories: async (_: any, { block = {}, first }: { first: number, block: BlockHeight }) => {
@@ -89,7 +122,40 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
       mints: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('mints', first, orderBy, orderDirection, where);
 
-        return indexer.getEntities(Mint, block, where, { limit: first, orderBy, orderDirection }, ['mint.pool', 'mint.transaction', 'pool.token0', 'pool.token1']);
+        return indexer.getEntities(
+          Mint,
+          block,
+          where,
+          { limit: first, orderBy, orderDirection },
+          [
+            {
+              entity: Pool,
+              type: 'one-to-one',
+              property: 'pool',
+              field: 'poolId',
+              childRelations: [
+                {
+                  entity: Token,
+                  type: 'one-to-one',
+                  property: 'token0',
+                  field: 'token0Id'
+                },
+                {
+                  entity: Token,
+                  type: 'one-to-one',
+                  property: 'token1',
+                  field: 'token1Id'
+                }
+              ]
+            },
+            {
+              entity: Transaction,
+              type: 'one-to-one',
+              property: 'transaction',
+              field: 'transactionId'
+            }
+          ]
+        );
       },
 
       pool: async (_: any, { id, block = {} }: { id: string, block: BlockHeight }) => {
@@ -107,13 +173,65 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
       pools: async (_: any, { block = {}, first, orderBy, orderDirection, where = {} }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('pools', block, first, orderBy, orderDirection, where);
 
-        return indexer.getEntities(Pool, block, where, { limit: first, orderBy, orderDirection }, ['pool.token0', 'pool.token1']);
+        return indexer.getEntities(
+          Pool,
+          block,
+          where,
+          { limit: first, orderBy, orderDirection },
+          [
+            {
+              entity: Token,
+              type: 'one-to-one',
+              property: 'token0',
+              field: 'token0Id'
+            },
+            {
+              entity: Token,
+              type: 'one-to-one',
+              property: 'token1',
+              field: 'token1Id'
+            }
+          ]
+        );
       },
 
       swaps: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('swaps', first, orderBy, orderDirection, where);
 
-        return indexer.getEntities(Swap, block, where, { limit: first, orderBy, orderDirection }, ['swap.pool', 'swap.transaction', 'pool.token0', 'pool.token1']);
+        return indexer.getEntities(
+          Swap,
+          block,
+          where,
+          { limit: first, orderBy, orderDirection },
+          [
+            {
+              entity: Pool,
+              type: 'one-to-one',
+              property: 'pool',
+              field: 'poolId',
+              childRelations: [
+                {
+                  entity: Token,
+                  type: 'one-to-one',
+                  property: 'token0',
+                  field: 'token0Id'
+                },
+                {
+                  entity: Token,
+                  type: 'one-to-one',
+                  property: 'token1',
+                  field: 'token1Id'
+                }
+              ]
+            },
+            {
+              entity: Transaction,
+              type: 'one-to-one',
+              property: 'transaction',
+              field: 'transactionId'
+            }
+          ]
+        );
       },
 
       ticks: async (_: any, { block = {}, first, skip, where = {} }: { block: BlockHeight, first: number, skip: number, where: { [key: string]: any } }) => {
@@ -155,56 +273,107 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
           where,
           { limit: first, orderBy, orderDirection },
           [
-            'transaction.mints',
-            'transaction.burns',
-            'transaction.swaps',
             {
-              property: 'mints.transaction',
-              alias: 'mintsTransaction'
+              entity: Mint,
+              type: 'one-to-many',
+              property: 'mints',
+              field: 'transactionId',
+              childRelations: [
+                {
+                  entity: Transaction,
+                  type: 'one-to-one',
+                  property: 'transaction',
+                  field: 'transactionId'
+                },
+                {
+                  entity: Pool,
+                  type: 'one-to-one',
+                  property: 'pool',
+                  field: 'poolId',
+                  childRelations: [
+                    {
+                      entity: Token,
+                      type: 'one-to-one',
+                      property: 'token0',
+                      field: 'token0Id'
+                    },
+                    {
+                      entity: Token,
+                      type: 'one-to-one',
+                      property: 'token1',
+                      field: 'token1Id'
+                    }
+                  ]
+                }
+              ]
             },
             {
-              property: 'burns.transaction',
-              alias: 'burnsTransaction'
+              entity: Burn,
+              type: 'one-to-many',
+              property: 'burns',
+              field: 'transactionId',
+              childRelations: [
+                {
+                  entity: Transaction,
+                  type: 'one-to-one',
+                  property: 'transaction',
+                  field: 'transactionId'
+                },
+                {
+                  entity: Pool,
+                  type: 'one-to-one',
+                  property: 'pool',
+                  field: 'poolId',
+                  childRelations: [
+                    {
+                      entity: Token,
+                      type: 'one-to-one',
+                      property: 'token0',
+                      field: 'token0Id'
+                    },
+                    {
+                      entity: Token,
+                      type: 'one-to-one',
+                      property: 'token1',
+                      field: 'token1Id'
+                    }
+                  ]
+                }
+              ]
             },
             {
-              property: 'swaps.transaction',
-              alias: 'swapsTransaction'
-            },
-            {
-              property: 'mints.pool',
-              alias: 'mintsPool'
-            },
-            {
-              property: 'burns.pool',
-              alias: 'burnsPool'
-            },
-            {
-              property: 'swaps.pool',
-              alias: 'swapsPool'
-            },
-            {
-              property: 'mintsPool.token0',
-              alias: 'mintsPoolToken0'
-            },
-            {
-              property: 'mintsPool.token1',
-              alias: 'mintsPoolToken1'
-            },
-            {
-              property: 'burnsPool.token0',
-              alias: 'burnsPoolToken0'
-            },
-            {
-              property: 'burnsPool.token1',
-              alias: 'burnsPoolToken1'
-            },
-            {
-              property: 'swapsPool.token0',
-              alias: 'swapsPoolToken0'
-            },
-            {
-              property: 'swapsPool.token1',
-              alias: 'swapsPoolToken1'
+              entity: Swap,
+              type: 'one-to-many',
+              property: 'swaps',
+              field: 'transactionId',
+              childRelations: [
+                {
+                  entity: Transaction,
+                  type: 'one-to-one',
+                  property: 'transaction',
+                  field: 'transactionId'
+                },
+                {
+                  entity: Pool,
+                  type: 'one-to-one',
+                  property: 'pool',
+                  field: 'poolId',
+                  childRelations: [
+                    {
+                      entity: Token,
+                      type: 'one-to-one',
+                      property: 'token0',
+                      field: 'token0Id'
+                    },
+                    {
+                      entity: Token,
+                      type: 'one-to-one',
+                      property: 'token1',
+                      field: 'token1Id'
+                    }
+                  ]
+                }
+              ]
             }
           ]
         );
@@ -225,12 +394,42 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
           where,
           { limit: first },
           [
-            'position.pool',
-            'position.token0',
-            'position.token1',
-            'position.tickLower',
-            'position.tickUpper',
-            'position.transaction'
+            {
+              entity: Pool,
+              type: 'one-to-one',
+              property: 'pool',
+              field: 'poolId'
+            },
+            {
+              entity: Token,
+              type: 'one-to-one',
+              property: 'token0',
+              field: 'token0Id'
+            },
+            {
+              entity: Token,
+              type: 'one-to-one',
+              property: 'token1',
+              field: 'token1Id'
+            },
+            {
+              entity: Tick,
+              type: 'one-to-one',
+              property: 'tickLower',
+              field: 'tickLowerId'
+            },
+            {
+              entity: Tick,
+              type: 'one-to-one',
+              property: 'tickUpper',
+              field: 'tickUpperId'
+            },
+            {
+              entity: Transaction,
+              type: 'one-to-one',
+              property: 'transaction',
+              field: 'transactionId'
+            }
           ]
         );
       },

--- a/packages/uni-info-watcher/src/schema.ts
+++ b/packages/uni-info-watcher/src/schema.ts
@@ -11,6 +11,17 @@ scalar BigInt
 
 scalar Bytes
 
+# https://thegraph.com/docs/en/developer/create-subgraph-hosted/#non-fatal-errors
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
+}
+
 input Block_height {
   hash: Bytes
   number: Int
@@ -38,6 +49,7 @@ type PoolDayData {
   id: ID!
   tvlUSD: BigDecimal!
   volumeUSD: BigDecimal!
+  feesUSD: BigDecimal!
 }
 
 type Tick {
@@ -335,6 +347,11 @@ type Query {
     block hash. Defaults to the latest block when omitted.
     """
     block: Block_height
+
+    """
+    Set to 'allow' to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): Bundle
 
   bundles(
@@ -346,6 +363,8 @@ type Query {
     block hash. Defaults to the latest block when omitted.
     """
     block: Block_height
+
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Bundle!]!
 
   burns(
@@ -354,6 +373,7 @@ type Query {
     orderDirection: OrderDirection
     where: Burn_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Burn!]!
 
   factories(
@@ -365,6 +385,8 @@ type Query {
     block hash. Defaults to the latest block when omitted.
     """
     block: Block_height
+
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Factory!]!
 
   mints(
@@ -373,6 +395,7 @@ type Query {
     orderDirection: OrderDirection
     where: Mint_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Mint!]!
 
   pool(
@@ -387,6 +410,7 @@ type Query {
     orderDirection: OrderDirection
     where: PoolDayData_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [PoolDayData!]!
 
   pools(
@@ -401,6 +425,8 @@ type Query {
     block hash. Defaults to the latest block when omitted.
     """
     block: Block_height
+
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Pool!]!
 
   swaps(
@@ -409,6 +435,7 @@ type Query {
     orderDirection: OrderDirection
     where: Swap_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Swap!]!
 
   ticks(
@@ -422,6 +449,8 @@ type Query {
     block hash. Defaults to the latest block when omitted.
     """
     block: Block_height
+
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Tick!]!
 
   token(
@@ -433,6 +462,8 @@ type Query {
     block hash. Defaults to the latest block when omitted.
     """
     block: Block_height
+
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): Token
 
   tokenDayDatas(
@@ -442,6 +473,7 @@ type Query {
     orderDirection: OrderDirection
     where: TokenDayData_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [TokenDayData!]!
 
   tokenHourDatas(
@@ -451,6 +483,7 @@ type Query {
     orderDirection: OrderDirection
     where: TokenHourData_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [TokenHourData!]!
 
   tokens(
@@ -459,6 +492,7 @@ type Query {
     orderDirection: OrderDirection
     where: Token_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Token!]!
 
   transactions(
@@ -467,6 +501,7 @@ type Query {
     orderDirection: OrderDirection
     where: Transaction_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Transaction!]!
 
   uniswapDayDatas(
@@ -476,12 +511,14 @@ type Query {
     orderDirection: OrderDirection
     where: UniswapDayData_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [UniswapDayData!]!
 
   positions(
     first: Int = 100
     where: Position_filter
     block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Position!]!
 
   blocks(
@@ -489,10 +526,11 @@ type Query {
     orderBy: Block_orderBy
     orderDirection: OrderDirection
     where: Block_filter
+    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Block!]!
 
   indexingStatusForCurrentVersion(
-    subgraphName: String
+    subgraphName: String!
   ): SubgraphIndexingStatus
 }
 

--- a/packages/uni-info-watcher/test/queries/inputParams.gql
+++ b/packages/uni-info-watcher/test/queries/inputParams.gql
@@ -1,0 +1,378 @@
+query inputParams($block: Block_height){
+  bundles(
+    block: $block
+    first: 1
+  ) {
+    ethPriceUSD
+  }
+
+  factories(
+    block: $block
+    first: 1
+  ) {
+    txCount
+    totalVolumeUSD
+    totalFeesUSD
+    totalValueLockedUSD
+  }
+
+  pools(
+    block: $block
+    # where: { id_in: $poolString, token0_in: $tokens, token1_in: $tokens, id: $id }
+    orderBy: totalValueLockedUSD
+    orderDirection: desc
+    first: 50
+  ) {
+    id
+    feeTier
+    liquidity
+    sqrtPrice
+    tick
+    token0 {
+      id
+      symbol
+      name
+      decimals
+      derivedETH
+    }
+    token1 {
+      id
+      symbol
+      name
+      decimals
+      derivedETH
+    }
+    token0Price
+    token1Price
+    volumeUSD
+    txCount
+    totalValueLockedToken0
+    totalValueLockedToken1
+    totalValueLockedUSD
+  }
+
+  asPools2: pools(
+    block: $block
+    first: 200
+    orderBy: totalValueLockedUSD
+    orderDirection: desc
+    # where: { token0: $address, token1: $address }
+  ) {
+    id
+  }
+
+  tokens(
+    block: $block
+    # where: { symbol_contains: $value, name_contains: $value, id: $id, id_in: $tokenString }
+    orderBy: totalValueLockedUSD
+    orderDirection: desc
+    first: 50
+  ) {
+    id
+    symbol
+    name
+    totalValueLockedUSD
+    derivedETH
+    volumeUSD
+    volume
+    txCount
+    totalValueLocked
+    feesUSD
+  }
+
+  mints(
+    block: $block
+    first: 100
+    orderBy: timestamp
+    orderDirection: desc
+    # where: { pool: $address }
+  ) {
+    timestamp
+    transaction {
+      id
+    }
+    pool {
+      token0 {
+        id
+        symbol
+      }
+      token1 {
+        id
+        symbol
+      }
+    }
+    owner
+    sender
+    origin
+    amount0
+    amount1
+    amountUSD
+  }
+
+  swaps(
+    block: $block
+    first: 100
+    orderBy: timestamp
+    orderDirection: desc
+    # where: { pool: $address }
+  ) {
+    timestamp
+    transaction {
+      id
+    }
+    pool {
+      token0 {
+        id
+        symbol
+      }
+      token1 {
+        id
+        symbol
+      }
+    }
+    origin
+    amount0
+    amount1
+    amountUSD
+  }
+
+  burns(
+    block: $block
+    first: 100
+    orderBy: timestamp
+    orderDirection: desc
+    # where: { pool: $address }
+  ) {
+    timestamp
+    transaction {
+      id
+    }
+    pool {
+      token0 {
+        id
+        symbol
+      }
+      token1 {
+        id
+        symbol
+      }
+    }
+    owner
+    amount0
+    amount1
+    amountUSD
+  }
+
+  asMints2: mints(
+    block: $block
+    first: 500
+    orderBy: timestamp
+    orderDirection: desc
+    # where: { token0: $address }
+  ) {
+    timestamp
+    transaction {
+      id
+    }
+    pool {
+      token0 {
+        id
+        symbol
+      }
+      token1 {
+        id
+        symbol
+      }
+    }
+    owner
+    sender
+    origin
+    amount0
+    amount1
+    amountUSD
+  }
+
+  asSwaps2: swaps(
+    block: $block
+    first: 500
+    orderBy: timestamp
+    orderDirection: desc
+    # where: { token0: $address }
+  ) {
+    timestamp
+    transaction {
+      id
+    }
+    pool {
+      token0 {
+        id
+        symbol
+      }
+      token1 {
+        id
+        symbol
+      }
+    }
+    origin
+    amount0
+    amount1
+    amountUSD
+  }
+
+  asBurns2: burns(
+    block: $block
+    first: 500
+    orderBy: timestamp
+    orderDirection: desc
+    # where: { token0: $address }
+  ) {
+    timestamp
+    transaction {
+      id
+    }
+    pool {
+      token0 {
+        id
+        symbol
+      }
+      token1 {
+        id
+        symbol
+      }
+    }
+    owner
+    amount0
+    amount1
+    amountUSD
+  }
+
+  transactions(
+    block: $block
+    first: 500
+    orderBy: timestamp
+    orderDirection: desc
+  ) {
+    id
+    timestamp
+    mints {
+      pool {
+        token0 {
+          id
+          symbol
+        }
+        token1 {
+          id
+          symbol
+        }
+      }
+      owner
+      sender
+      origin
+      amount0
+      amount1
+      amountUSD
+    }
+    swaps {
+      pool {
+        token0 {
+          id
+          symbol
+        }
+        token1 {
+          id
+          symbol
+        }
+      }
+      origin
+      amount0
+      amount1
+      amountUSD
+    }
+    burns {
+      pool {
+        token0 {
+          id
+          symbol
+        }
+        token1 {
+          id
+          symbol
+        }
+      }
+      owner
+      origin
+      amount0
+      amount1
+      amountUSD
+    }
+  }
+
+  uniswapDayDatas(
+    block: $block
+    first: 1000
+    # skip: $skip
+    # where: { date_gt: $startTime }
+    orderBy: date
+    orderDirection: asc
+  ) {
+    id
+    date
+    volumeUSD
+    tvlUSD
+  }
+
+  poolDayDatas(
+    block: $block
+    first: 1000
+    # skip: $skip
+    # where: { pool: $address, date_gt: $startTime }
+    orderBy: date
+    orderDirection: asc
+  ) {
+    date
+    volumeUSD
+    tvlUSD
+    feesUSD
+  }
+
+  tokenDayDatas(
+    block: $block
+    first: 1000
+    # skip: $skip
+    # where: { token: $address, date_gt: $startTime }
+    orderBy: date
+    orderDirection: asc
+  ) {
+    date
+    volumeUSD
+    totalValueLockedUSD
+  }
+
+  tokenHourDatas(
+    block: $block
+    first: 100
+    # skip: $skip
+    # where: { token: $address, periodStartUnix_gt: $startTime }
+    orderBy: periodStartUnix
+    orderDirection: asc
+  ) {
+    periodStartUnix
+    high
+    low
+    open
+    close
+  }
+
+  ticks(
+    block: $block
+    first: 1000
+    # skip: $skip
+    # where: { poolAddress: $poolAddress, tickIdx_lte: $tickIdxUpperBound, tickIdx_gte: $tickIdxLowerBound }
+  ) {
+    tickIdx
+    liquidityGross
+    liquidityNet
+    price0
+    price1
+  }
+}

--- a/packages/uni-info-watcher/test/queries/nested.gql
+++ b/packages/uni-info-watcher/test/queries/nested.gql
@@ -1,0 +1,210 @@
+query nested($block: Block_height){
+  bundles(block: $block) {
+    ethPriceUSD
+  }
+
+  factories(block: $block) {
+    txCount
+    totalVolumeUSD
+    totalFeesUSD
+    totalValueLockedUSD
+  }
+
+  pools(block: $block) {
+    id
+    feeTier
+    liquidity
+    sqrtPrice
+    tick
+    token0 {
+      id
+      symbol
+      name
+      decimals
+      derivedETH
+    }
+    token1 {
+      id
+      symbol
+      name
+      decimals
+      derivedETH
+    }
+    token0Price
+    token1Price
+    volumeUSD
+    txCount
+    totalValueLockedToken0
+    totalValueLockedToken1
+    totalValueLockedUSD
+  }
+
+  tokens(block: $block) {
+    id
+    symbol
+    name
+    totalValueLockedUSD
+    derivedETH
+    volumeUSD
+    volume
+    txCount
+    totalValueLocked
+    feesUSD
+  }
+
+  mints(block: $block) {
+    timestamp
+    transaction {
+      id
+    }
+    pool {
+      token0 {
+        id
+        symbol
+      }
+      token1 {
+        id
+        symbol
+      }
+    }
+    owner
+    sender
+    origin
+    amount0
+    amount1
+    amountUSD
+  }
+
+  swaps(block: $block) {
+    timestamp
+    transaction {
+      id
+    }
+    pool {
+      token0 {
+        id
+        symbol
+      }
+      token1 {
+        id
+        symbol
+      }
+    }
+    origin
+    amount0
+    amount1
+    amountUSD
+  }
+
+  burns(block: $block) {
+    timestamp
+    transaction {
+      id
+    }
+    pool {
+      token0 {
+        id
+        symbol
+      }
+      token1 {
+        id
+        symbol
+      }
+    }
+    owner
+    amount0
+    amount1
+    amountUSD
+  }
+
+  transactions(block: $block) {
+    id
+    timestamp
+    mints {
+      pool {
+        token0 {
+          id
+          symbol
+        }
+        token1 {
+          id
+          symbol
+        }
+      }
+      owner
+      sender
+      origin
+      amount0
+      amount1
+      amountUSD
+    }
+    swaps {
+      pool {
+        token0 {
+          id
+          symbol
+        }
+        token1 {
+          id
+          symbol
+        }
+      }
+      origin
+      amount0
+      amount1
+      amountUSD
+    }
+    burns {
+      pool {
+        token0 {
+          id
+          symbol
+        }
+        token1 {
+          id
+          symbol
+        }
+      }
+      owner
+      origin
+      amount0
+      amount1
+      amountUSD
+    }
+  }
+
+  uniswapDayDatas(block: $block) {
+    id
+    date
+    volumeUSD
+    tvlUSD
+  }
+
+  poolDayDatas(block: $block) {
+    date
+    volumeUSD
+    tvlUSD
+  }
+
+  tokenDayDatas(block: $block) {
+    date
+    volumeUSD
+    totalValueLockedUSD
+  }
+
+  tokenHourDatas(block: $block) {
+    periodStartUnix
+    high
+    low
+    open
+    close
+  }
+
+  ticks(block: $block) {
+    tickIdx
+    liquidityGross
+    liquidityNet
+    price0
+    price1
+  }
+}

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -386,6 +386,8 @@ export class Database {
       selectQueryBuilder = this._orderQuery(repo, selectQueryBuilder, queryOptions);
     }
 
+    selectQueryBuilder = this._orderQuery(repo, selectQueryBuilder, { ...queryOptions, orderBy: 'id' });
+
     const { limit = DEFAULT_LIMIT, skip = DEFAULT_SKIP } = queryOptions;
 
     selectQueryBuilder = selectQueryBuilder.offset(skip)
@@ -411,6 +413,8 @@ export class Database {
       if (queryOptions.orderBy) {
         relationQueryBuilder = this._orderQuery(repo, relationQueryBuilder, queryOptions);
       }
+
+      relationQueryBuilder = this._orderQuery(repo, relationQueryBuilder, { ...queryOptions, orderBy: 'id' });
 
       // Load entity ids for many to many relations.
       manyToManyRelations.forEach(relation => {
@@ -450,7 +454,6 @@ export class Database {
             block,
             where,
             {
-              orderBy: 'id',
               limit: queryOptions.limit
             },
             childRelations
@@ -498,7 +501,7 @@ export class Database {
             block,
             where,
             {
-              limit: queryOptions.limit
+              limit: relatedIds.size
             },
             childRelations
           );

--- a/packages/util/src/database.ts
+++ b/packages/util/src/database.ts
@@ -722,9 +722,7 @@ export class Database {
 
         whereClause += `${OPERATOR_MAP[operator]} `;
 
-        if (['contains', 'starts'].some(el => el === operator)) {
-          whereClause += '%:';
-        } else if (operator === 'in') {
+        if (operator === 'in') {
           whereClause += '(:...';
         } else {
           // Convert to string type value as bigint type throws error in query.
@@ -736,14 +734,20 @@ export class Database {
         const variableName = `${field}${index}`;
         whereClause += variableName;
 
-        if (['contains', 'ends'].some(el => el === operator)) {
-          whereClause += '%';
-        } else if (operator === 'in') {
+        if (operator === 'in') {
           whereClause += ')';
 
           if (!value.length) {
             whereClause = 'FALSE';
           }
+        }
+
+        if (['contains', 'starts'].some(el => el === operator)) {
+          value = `%${value}`;
+        }
+
+        if (['contains', 'ends'].some(el => el === operator)) {
+          value += '%';
         }
 
         selectQueryBuilder = selectQueryBuilder.andWhere(whereClause, { [variableName]: value });


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

- Implement query for nested relations of one to one and one to many.
- Implement query for nested relations of many to many.
- Add `subgraphError` input param used in frontend app.
- Fix query for input params like `where` and `orderBy`.
- Fix query for string search in entities.
- Add index for foreign key transactionId to improve query.
- Use simpler query for fetching block entities.