### PR TITLE
Fix query limit in one to many relation and duplicate events in uni-watcher

### DIFF
--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -153,7 +153,6 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash, number: blockNumber },
-        {},
         [
           {
             entity: Pool,
@@ -212,7 +211,6 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash, number: blockNumber },
-        {},
         [
           {
             entity: Token,
@@ -278,7 +276,6 @@ export class Database implements DatabaseInterface {
         [entity] = await this._baseDatabase.loadRelations(
           queryRunner,
           { hash: blockHash },
-          {},
           [
             {
               entity: Pool,
@@ -352,7 +349,6 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
-        {},
         [
           {
             entity: Pool,
@@ -407,7 +403,6 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
-        {},
         [
           {
             entity: Pool,
@@ -448,7 +443,6 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
-        {},
         [
           {
             entity: Pool,
@@ -513,7 +507,6 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
-        {},
         [
           {
             entity: Token,
@@ -554,7 +547,6 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
-        {},
         [
           {
             entity: Token,
@@ -595,7 +587,6 @@ export class Database implements DatabaseInterface {
       [entity] = await this._baseDatabase.loadRelations(
         queryRunner,
         { hash: blockHash },
-        {},
         [
           {
             entity: Tick,

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -36,6 +36,7 @@ import { Tick } from './entity/Tick';
 import { Contract, KIND_POOL } from './entity/Contract';
 
 const SYNC_DELTA = 5;
+const DEFAULT_LIMIT = 100;
 
 const log = debug('vulcanize:indexer');
 
@@ -179,7 +180,7 @@ export class Indexer implements IndexerInterface {
       where,
       {
         order,
-        take: queryOptions.limit
+        take: queryOptions.limit ?? DEFAULT_LIMIT
       }
     );
 
@@ -297,6 +298,10 @@ export class Indexer implements IndexerInterface {
 
         return acc;
       }, {});
+
+      if (!queryOptions.limit) {
+        queryOptions.limit = DEFAULT_LIMIT;
+      }
 
       res = await this._db.getModelEntities(dbTx, entity, block, where, queryOptions, relations);
       dbTx.commitTransaction();

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -287,7 +287,7 @@ export class JobRunner {
       dbEvents = watchedContractEvents;
     }
 
-    for (let dbEvent of dbEvents) {
+    for (const dbEvent of dbEvents) {
       if (dbEvent.index <= block.lastProcessedEventIndex) {
         continue;
       }
@@ -323,7 +323,6 @@ export class JobRunner {
 
           dbEvent.eventName = eventName;
           dbEvent.eventInfo = JSON.stringify(eventInfo);
-          dbEvent = await this._indexer.saveEventEntity(dbEvent);
         }
 
         await this._indexer.processEvent(dbEvent);


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/292

- Remove default limit in query for one to many relation entities.
  Mismatch was found in Transaction entity query at block 12381385 (start block + 11764)
- Fix unknown events of watched contracts getting saved twice in uni-watcher.
  Mismatch was found in UniswapDayData entity query at block 12386584 (start block + 16963)