### PR TITLE
Deprecate postgraphile usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 out/
+.vscode

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The default config files used by the watchers assume the following services are 
 
 * `vulcanize/go-ethereum` on port 8545
 * `vulcanize/ipld-eth-server` with native GQL API enabled on port 8082 and RPC API on port 8081
-* `postgraphile` on the `vulcanize/ipld-eth-server` database, on port 5000
 
 To check whether the endpoints in watcher config are working, run:
 
@@ -31,8 +30,6 @@ yarn check-config --config-file ../erc20-watcher/environments/local.toml
 yarn check-config --config-file ../uni-watcher/environments/local.toml
 # vulcanize:check-config Checking ipld-eth-server GQL endpoint http://127.0.0.1:8082/graphql +0ms
 # vulcanize:check-config ipld-eth-server GQL endpoint working +33ms
-# vulcanize:check-config Checking postgraphile GQL endpoint http://127.0.0.1:5000/graphql +1ms
-# vulcanize:check-config postgraphile GQL endpoint working +12ms
 # vulcanize:check-config Checking RPC endpoint http://127.0.0.1:8081 +1ms
 # vulcanize:check-config RPC endpoint working +25ms
 ```

--- a/packages/address-watcher/README.md
+++ b/packages/address-watcher/README.md
@@ -34,7 +34,7 @@ createdb address-watcher
 
 Update `environments/local.toml` with database connection settings for both the databases.
 
-Update the `upstream` config in `environments/local.toml` and provide the `ipld-eth-server` GQL API, the `indexer-db` postgraphile and the tracing API (`debug_traceTransaction` RPC provider) endpoints.
+Update the `upstream` config in `environments/local.toml` and provide the `ipld-eth-server` GQL API and the tracing API (`debug_traceTransaction` RPC provider) endpoints.
 
 ## Run
 

--- a/packages/address-watcher/environments/local.toml
+++ b/packages/address-watcher/environments/local.toml
@@ -17,7 +17,6 @@
 
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
 
   [upstream.cache]
     name = "requests"

--- a/packages/address-watcher/src/fill.ts
+++ b/packages/address-watcher/src/fill.ts
@@ -55,14 +55,13 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlPostgraphileEndpoint }, traceProviderEndpoint, cache: cacheConfig } = upstream;
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
+  const { ethServer: { gqlApiEndpoint }, traceProviderEndpoint, cache: cacheConfig } = upstream;
+  assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
   assert(traceProviderEndpoint, 'Missing upstream traceProviderEndpoint');
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
+    gqlEndpoint: gqlApiEndpoint,
     cache
   });
 

--- a/packages/address-watcher/src/job-runner.ts
+++ b/packages/address-watcher/src/job-runner.ts
@@ -42,15 +42,13 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint }, traceProviderEndpoint, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint }, traceProviderEndpoint, cache: cacheConfig } = upstream;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
   assert(traceProviderEndpoint, 'Missing upstream traceProviderEndpoint');
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/address-watcher/src/server.ts
+++ b/packages/address-watcher/src/server.ts
@@ -50,15 +50,13 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint }, traceProviderEndpoint, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint }, traceProviderEndpoint, cache: cacheConfig } = upstream;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
   assert(traceProviderEndpoint, 'Missing upstream traceProviderEndpoint');
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/address-watcher/src/tx-watcher.ts
+++ b/packages/address-watcher/src/tx-watcher.ts
@@ -67,11 +67,12 @@ export class TxWatcher {
       }
     });
 
-    this._watchTxSubscription = await this._ethClient.watchTransactions(async (value) => {
-      const { txHash, ethHeaderCidByHeaderId: { blockHash, blockNumber } } = _.get(value, 'data.listen.relatedNode');
-      log('watchTransaction', JSON.stringify({ txHash, blockHash, blockNumber }, null, 2));
-      await this._jobQueue.pushJob(QUEUE_TX_TRACING, { txHash, blockHash, publish: true });
-    });
+    // TODO: Update to pull based watcher.
+    // this._watchTxSubscription = await this._ethClient.watchTransactions(async (value) => {
+    //   const { txHash, ethHeaderCidByHeaderId: { blockHash, blockNumber } } = _.get(value, 'data.listen.relatedNode');
+    //   log('watchTransaction', JSON.stringify({ txHash, blockHash, blockNumber }, null, 2));
+    //   await this._jobQueue.pushJob(QUEUE_TX_TRACING, { txHash, blockHash, publish: true });
+    // });
   }
 
   async publishAddressEventToSubscribers (txHash: string, timeElapsedInSeconds: number): Promise<void> {

--- a/packages/codegen/src/templates/config-template.handlebars
+++ b/packages/codegen/src/templates/config-template.handlebars
@@ -16,7 +16,6 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
     blockDelayInMilliSecs = 2000
 

--- a/packages/codegen/src/templates/events-template.handlebars
+++ b/packages/codegen/src/templates/events-template.handlebars
@@ -31,7 +31,7 @@ export class EventWatcher {
   _pubsub: PubSub
   _jobQueue: JobQueue
 
-  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, postgraphileClient: EthClient, indexer: Indexer, pubsub: PubSub, jobQueue: JobQueue) {
+  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, indexer: Indexer, pubsub: PubSub, jobQueue: JobQueue) {
     assert(ethClient);
     assert(indexer);
 
@@ -39,7 +39,7 @@ export class EventWatcher {
     this._indexer = indexer;
     this._pubsub = pubsub;
     this._jobQueue = jobQueue;
-    this._baseEventWatcher = new BaseEventWatcher(upstreamConfig, this._ethClient, postgraphileClient, this._indexer, this._pubsub, this._jobQueue);
+    this._baseEventWatcher = new BaseEventWatcher(upstreamConfig, this._ethClient, this._indexer, this._pubsub, this._jobQueue);
   }
 
   getEventIterator (): AsyncIterator<any> {

--- a/packages/codegen/src/templates/fill-template.handlebars
+++ b/packages/codegen/src/templates/fill-template.handlebars
@@ -54,19 +54,12 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig } = upstream;
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig } = upstream;
 
   const cache = await getCache(cacheConfig);
 
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -75,7 +68,7 @@ export const main = async (): Promise<any> => {
   // Note: In-memory pubsub works fine for now, as each watcher is a single process anyway.
   // Later: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries
   const pubsub = new PubSub();
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider);
+  const indexer = new Indexer(db, ethClient, ethProvider);
 
   const { dbConnectionString, maxCompletionLagInSecs } = jobQueueConfig;
   assert(dbConnectionString, 'Missing job queue db connection string');
@@ -83,11 +76,11 @@ export const main = async (): Promise<any> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const eventWatcher = new EventWatcher(upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
+  const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
 
   assert(jobQueueConfig, 'Missing job queue config');
 
-  await fillBlocks(jobQueue, indexer, postgraphileClient, eventWatcher, blockDelayInMilliSecs, argv);
+  await fillBlocks(jobQueue, indexer, eventWatcher, blockDelayInMilliSecs, argv);
 };
 
 main().catch(err => {

--- a/packages/codegen/src/templates/indexer-template.handlebars
+++ b/packages/codegen/src/templates/indexer-template.handlebars
@@ -54,22 +54,20 @@ export class Indexer {
   _db: Database
   _ethClient: EthClient
   _ethProvider: BaseProvider
-  _postgraphileClient: EthClient;
   _baseIndexer: BaseIndexer
 
   _abi: JsonFragment[]
   _storageLayout: StorageLayout
   _contract: ethers.utils.Interface
 
-  constructor (db: Database, ethClient: EthClient, postgraphileClient: EthClient, ethProvider: BaseProvider) {
+  constructor (db: Database, ethClient: EthClient, ethProvider: BaseProvider) {
     assert(db);
     assert(ethClient);
 
     this._db = db;
     this._ethClient = ethClient;
-    this._postgraphileClient = postgraphileClient;
     this._ethProvider = ethProvider;
-    this._baseIndexer = new BaseIndexer(this._db, this._ethClient, this._postgraphileClient, this._ethProvider);
+    this._baseIndexer = new BaseIndexer(this._db, this._ethClient, this._ethProvider);
 
     const { abi, storageLayout } = artifacts;
 
@@ -306,7 +304,7 @@ export class Indexer {
           }
         ]
       }
-    } = await this._postgraphileClient.getBlockWithTransactions({ blockHash });
+    } = await this._ethClient.getBlockWithTransactions({ blockHash });
 
     const transactionMap = transactions.reduce((acc: {[key: string]: any}, transaction: {[key: string]: any}) => {
       acc[transaction.txHash] = transaction;

--- a/packages/codegen/src/templates/job-runner-template.handlebars
+++ b/packages/codegen/src/templates/job-runner-template.handlebars
@@ -90,25 +90,18 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
 
   const cache = await getCache(cacheConfig);
 
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
   const ethProvider = getCustomProvider(rpcProviderEndpoint);
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider);
+  const indexer = new Indexer(db, ethClient, ethProvider);
 
   assert(jobQueueConfig, 'Missing job queue config');
 

--- a/packages/codegen/src/templates/readme-template.handlebars
+++ b/packages/codegen/src/templates/readme-template.handlebars
@@ -37,14 +37,14 @@
 
 * Update the [config](./environments/local.toml) with database connection settings.
 
-* Update the `upstream` config in the [config file](./environments/local.toml) and provide the `ipld-eth-server` GQL API and the `indexer-db` postgraphile endpoints.
+* Update the `upstream` config in the [config file](./environments/local.toml) and provide the `ipld-eth-server` GQL API endpoint.
 
 ## Customize
 
 * Indexing on an event:
 
   * Edit the custom hook function `handleEvent` (triggered on an event) in [hooks.ts](./src/hooks.ts) to perform corresponding indexing using the `Indexer` object.
-  
+
   * Refer to [hooks.example.ts](./src/hooks.example.ts) for an example hook function for events in an ERC20 contract.
 
 ## Run

--- a/packages/codegen/src/templates/server-template.handlebars
+++ b/packages/codegen/src/templates/server-template.handlebars
@@ -50,26 +50,19 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
 
   const cache = await getCache(cacheConfig);
 
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
   const ethProvider = getCustomProvider(rpcProviderEndpoint);
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider);
+  const indexer = new Indexer(db, ethClient, ethProvider);
 
   // Note: In-memory pubsub works fine for now, as each watcher is a single process anyway.
   // Later: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries
@@ -81,7 +74,7 @@ export const main = async (): Promise<any> => {
 
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
 
-  const eventWatcher = new EventWatcher(upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
+  const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
 
   if (watcherKind === KIND_ACTIVE) {
     await jobQueue.start();

--- a/packages/erc20-watcher/README.md
+++ b/packages/erc20-watcher/README.md
@@ -34,7 +34,7 @@ createdb erc20-watcher
 
 Update `environments/local.toml` with database connection settings for both the databases.
 
-Update the `upstream` config in `environments/local.toml` and provide the `ipld-eth-server` GQL API and the `indexer-db` postgraphile endpoints.
+Update the `upstream` config in `environments/local.toml` and provide the `ipld-eth-server` GQL API endpoint.
 
 ## Run
 

--- a/packages/erc20-watcher/environments/local.toml
+++ b/packages/erc20-watcher/environments/local.toml
@@ -18,7 +18,6 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
     blockDelayInMilliSecs = 2000
 

--- a/packages/erc20-watcher/environments/local.toml
+++ b/packages/erc20-watcher/environments/local.toml
@@ -18,7 +18,7 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
+    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
     blockDelayInMilliSecs = 2000
 

--- a/packages/erc20-watcher/src/cli/reset-cmds/state.ts
+++ b/packages/erc20-watcher/src/cli/reset-cmds/state.ts
@@ -31,7 +31,7 @@ export const handler = async (argv: any): Promise<void> => {
   const config = await getConfig(argv.configFile);
   await resetJobs(config);
   const { jobQueue: jobQueueConfig } = config;
-  const { dbConfig, serverConfig, ethClient, postgraphileClient, ethProvider } = await getResetConfig(config);
+  const { dbConfig, serverConfig, ethClient, ethProvider } = await getResetConfig(config);
 
   // Initialize database.
   const db = new Database(dbConfig);
@@ -44,7 +44,7 @@ export const handler = async (argv: any): Promise<void> => {
 
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue, serverConfig.mode);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue, serverConfig.mode);
 
   const syncStatus = await indexer.getSyncStatus();
   assert(syncStatus, 'Missing syncStatus');

--- a/packages/erc20-watcher/src/cli/watch-contract.ts
+++ b/packages/erc20-watcher/src/cli/watch-contract.ts
@@ -38,7 +38,7 @@ import { Indexer } from '../indexer';
 
   const config: Config = await getConfig(argv.configFile);
   const { database: dbConfig, server: { mode }, jobQueue: jobQueueConfig } = config;
-  const { ethClient, postgraphileClient, ethProvider } = await getResetConfig(config);
+  const { ethClient, ethProvider } = await getResetConfig(config);
 
   assert(dbConfig);
 
@@ -53,7 +53,7 @@ import { Indexer } from '../indexer';
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue, mode);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue, mode);
 
   await indexer.watchContract(argv.address, argv.startingBlock);
 

--- a/packages/erc20-watcher/src/events.ts
+++ b/packages/erc20-watcher/src/events.ts
@@ -31,7 +31,7 @@ export class EventWatcher {
   _pubsub: PubSub
   _jobQueue: JobQueue
 
-  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, postgraphileClient: EthClient, indexer: Indexer, pubsub: PubSub, jobQueue: JobQueue) {
+  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, indexer: Indexer, pubsub: PubSub, jobQueue: JobQueue) {
     assert(ethClient);
     assert(indexer);
 
@@ -39,7 +39,7 @@ export class EventWatcher {
     this._indexer = indexer;
     this._pubsub = pubsub;
     this._jobQueue = jobQueue;
-    this._baseEventWatcher = new BaseEventWatcher(upstreamConfig, this._ethClient, postgraphileClient, this._indexer, this._pubsub, this._jobQueue);
+    this._baseEventWatcher = new BaseEventWatcher(upstreamConfig, this._ethClient, this._indexer, this._pubsub, this._jobQueue);
   }
 
   getEventIterator (): AsyncIterator<any> {

--- a/packages/erc20-watcher/src/fill.ts
+++ b/packages/erc20-watcher/src/fill.ts
@@ -73,7 +73,6 @@ export const main = async (): Promise<any> => {
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/erc20-watcher/src/fill.ts
+++ b/packages/erc20-watcher/src/fill.ts
@@ -67,17 +67,11 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig } = upstream;
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig } = upstream;
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -93,9 +87,9 @@ export const main = async (): Promise<any> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue, mode);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue, mode);
 
-  const eventWatcher = new EventWatcher(upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
+  const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
 
   assert(jobQueueConfig, 'Missing job queue config');
 

--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -46,7 +46,6 @@ interface EventResult {
 export class Indexer {
   _db: Database
   _ethClient: EthClient
-  _postgraphileClient: EthClient
   _ethProvider: BaseProvider
   _baseIndexer: BaseIndexer
 
@@ -55,16 +54,15 @@ export class Indexer {
   _contract: ethers.utils.Interface
   _serverMode: string
 
-  constructor (db: Database, ethClient: EthClient, postgraphileClient: EthClient, ethProvider: BaseProvider, jobQueue: JobQueue, serverMode: string) {
+  constructor (db: Database, ethClient: EthClient, ethProvider: BaseProvider, jobQueue: JobQueue, serverMode: string) {
     assert(db);
     assert(ethClient);
 
     this._db = db;
     this._ethClient = ethClient;
-    this._postgraphileClient = postgraphileClient;
     this._ethProvider = ethProvider;
     this._serverMode = serverMode;
-    this._baseIndexer = new BaseIndexer(this._db, this._ethClient, this._postgraphileClient, this._ethProvider, jobQueue);
+    this._baseIndexer = new BaseIndexer(this._db, this._ethClient, this._ethProvider, jobQueue);
 
     const { abi, storageLayout } = artifacts;
 

--- a/packages/erc20-watcher/src/job-runner.ts
+++ b/packages/erc20-watcher/src/job-runner.ts
@@ -80,18 +80,12 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -105,7 +99,7 @@ export const main = async (): Promise<any> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue, mode);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue, mode);
 
   const jobRunner = new JobRunner(jobQueueConfig, indexer, jobQueue);
   await jobRunner.start();

--- a/packages/erc20-watcher/src/job-runner.ts
+++ b/packages/erc20-watcher/src/job-runner.ts
@@ -87,7 +87,6 @@ export const main = async (): Promise<any> => {
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/erc20-watcher/src/server.ts
+++ b/packages/erc20-watcher/src/server.ts
@@ -51,18 +51,12 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -79,9 +73,9 @@ export const main = async (): Promise<any> => {
 
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue, mode);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue, mode);
 
-  const eventWatcher = new EventWatcher(upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
+  const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
 
   if (watcherKind === KIND_ACTIVE) {
     await jobQueue.start();

--- a/packages/erc20-watcher/src/server.ts
+++ b/packages/erc20-watcher/src/server.ts
@@ -58,7 +58,6 @@ export const main = async (): Promise<any> => {
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/ipld-eth-client/src/eth-client.ts
+++ b/packages/ipld-eth-client/src/eth-client.ts
@@ -76,7 +76,7 @@ export class EthClient {
     return this._graphqlClient.query(
       ethQueries.getBlocks,
       {
-        blockNumber,
+        blockNumber: blockNumber?.toString(),
         blockHash
       }
     );

--- a/packages/ipld-eth-client/src/eth-client.ts
+++ b/packages/ipld-eth-client/src/eth-client.ts
@@ -113,14 +113,6 @@ export class EthClient {
     return { logs, block };
   }
 
-  async watchBlocks (onNext: (value: any) => void): Promise<ZenObservable.Subscription> {
-    return this._graphqlClient.subscribe(ethQueries.subscribeBlocks, onNext);
-  }
-
-  async watchTransactions (onNext: (value: any) => void): Promise<ZenObservable.Subscription> {
-    return this._graphqlClient.subscribe(ethQueries.subscribeTransactions, onNext);
-  }
-
   async _getCachedOrFetch (queryName: keyof typeof ethQueries, vars: Vars): Promise<any> {
     const keyObj = {
       queryName,

--- a/packages/ipld-eth-client/src/eth-queries.ts
+++ b/packages/ipld-eth-client/src/eth-queries.ts
@@ -95,44 +95,10 @@ query block($blockHash: Bytes32) {
 }
 `;
 
-export const subscribeBlocks = gql`
-subscription {
-  listen(topic: "header_cids") {
-    relatedNode {
-      ... on EthHeaderCid {
-        blockHash
-        blockNumber
-        parentHash
-        timestamp
-      }
-    }
-  }
-}
-`;
-
-export const subscribeTransactions = gql`
-subscription SubscriptionHeader {
-  listen(topic: "transaction_cids") {
-    relatedNode {
-      ... on EthTransactionCid {
-        txHash
-        ethHeaderCidByHeaderId {
-          blockHash
-          blockNumber
-          parentHash
-        }
-      }
-    }
-  }
-}
-`;
-
 export default {
   getStorageAt,
   getLogs,
   getBlockWithTransactions,
   getBlocks,
-  getBlockByHash,
-  subscribeBlocks,
-  subscribeTransactions
+  getBlockByHash
 };

--- a/packages/lighthouse-watcher/environments/local.toml
+++ b/packages/lighthouse-watcher/environments/local.toml
@@ -8,7 +8,6 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
 
   [upstream.cache]
     name = "requests"

--- a/packages/lighthouse-watcher/src/events.ts
+++ b/packages/lighthouse-watcher/src/events.ts
@@ -38,16 +38,18 @@ export class EventWatcher {
 
   async watchBlocksAtChainHead (): Promise<void> {
     log('Started watching upstream blocks...');
-    this._subscription = await this._ethClient.watchBlocks(async (value) => {
-      const { blockHash, blockNumber } = _.get(value, 'data.listen.relatedNode');
-      log('watchBlock', blockHash, blockNumber);
 
-      const events = await this._indexer.getOrFetchBlockEvents(blockHash);
+    // TODO: Update to pull based watcher.
+    // this._subscription = await this._ethClient.watchBlocks(async (value) => {
+    //   const { blockHash, blockNumber } = _.get(value, 'data.listen.relatedNode');
+    //   log('watchBlock', blockHash, blockNumber);
 
-      for (let ei = 0; ei < events.length; ei++) {
-        await this.publishLighthouseEventToSubscribers(events[ei]);
-      }
-    });
+    //   const events = await this._indexer.getOrFetchBlockEvents(blockHash);
+
+    //   for (let ei = 0; ei < events.length; ei++) {
+    //     await this.publishLighthouseEventToSubscribers(events[ei]);
+    //   }
+    // });
   }
 
   async publishLighthouseEventToSubscribers (resultEvent: ResultEvent): Promise<void> {

--- a/packages/lighthouse-watcher/src/indexer.ts
+++ b/packages/lighthouse-watcher/src/indexer.ts
@@ -37,15 +37,13 @@ export interface Config extends BaseConfig {
 export class Indexer {
   _config: Config
   _ethClient: EthClient
-  _postgraphileClient: EthClient
 
   _lighthouseContract: ethers.utils.Interface
 
-  constructor (config: Config, ethClient: EthClient, postgraphileClient: EthClient) {
+  constructor (config: Config, ethClient: EthClient) {
     assert(config.watch);
     this._config = config;
     this._ethClient = ethClient;
-    this._postgraphileClient = postgraphileClient;
 
     this._lighthouseContract = new ethers.utils.Interface(lighthouseABI);
   }
@@ -96,7 +94,7 @@ export class Indexer {
           }
         ]
       }
-    } = await this._postgraphileClient.getBlockWithTransactions({ blockHash });
+    } = await this._ethClient.getBlockWithTransactions({ blockHash });
 
     const transactionMap = transactions.reduce((acc: {[key: string]: any}, transaction: {[key: string]: any}) => {
       acc[transaction.txHash] = transaction;

--- a/packages/lighthouse-watcher/src/server.ts
+++ b/packages/lighthouse-watcher/src/server.ts
@@ -43,23 +43,16 @@ export const main = async (): Promise<any> => {
   const { upstream } = config;
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint }, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint }, cache: cacheConfig } = upstream;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
-    cache
-  });
-
-  const indexer = new Indexer(config, ethClient, postgraphileClient);
+  const indexer = new Indexer(config, ethClient);
 
   // Note: In-memory pubsub works fine for now, as each watcher is a single process anyway.
   // Later: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries

--- a/packages/uni-info-watcher/environments/local.toml
+++ b/packages/uni-info-watcher/environments/local.toml
@@ -23,7 +23,6 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
     blockDelayInMilliSecs = 2000
 

--- a/packages/uni-info-watcher/environments/local.toml
+++ b/packages/uni-info-watcher/environments/local.toml
@@ -23,7 +23,7 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
+    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
     blockDelayInMilliSecs = 2000
 

--- a/packages/uni-info-watcher/environments/test.toml
+++ b/packages/uni-info-watcher/environments/test.toml
@@ -18,7 +18,6 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8545"
     blockDelayInMilliSecs = 2000
 

--- a/packages/uni-info-watcher/environments/test.toml
+++ b/packages/uni-info-watcher/environments/test.toml
@@ -18,7 +18,7 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
+    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8545"
     blockDelayInMilliSecs = 2000
 

--- a/packages/uni-info-watcher/src/cli/reset-cmds/state.ts
+++ b/packages/uni-info-watcher/src/cli/reset-cmds/state.ts
@@ -48,7 +48,7 @@ export const handler = async (argv: any): Promise<void> => {
   const config = await getConfig(argv.configFile);
   await resetJobs(config);
   const { jobQueue: jobQueueConfig } = config;
-  const { dbConfig, serverConfig, upstreamConfig, ethClient, postgraphileClient, ethProvider } = await getResetConfig(config);
+  const { dbConfig, serverConfig, upstreamConfig, ethClient, ethProvider } = await getResetConfig(config);
 
   // Initialize database.
   const db = new Database(dbConfig);
@@ -70,7 +70,7 @@ export const handler = async (argv: any): Promise<void> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, uniClient, erc20Client, ethClient, postgraphileClient, ethProvider, jobQueue, serverConfig.mode);
+  const indexer = new Indexer(db, uniClient, erc20Client, ethClient, ethProvider, jobQueue, serverConfig.mode);
 
   const syncStatus = await indexer.getSyncStatus();
   assert(syncStatus, 'Missing syncStatus');

--- a/packages/uni-info-watcher/src/events.ts
+++ b/packages/uni-info-watcher/src/events.ts
@@ -124,12 +124,12 @@ export class EventWatcher implements EventWatcherInterface {
   _jobQueue: JobQueue
   _baseEventWatcher: BaseEventWatcher
 
-  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, postgraphileClient: EthClient, indexer: Indexer, pubsub: PubSub, jobQueue: JobQueue) {
+  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, indexer: Indexer, pubsub: PubSub, jobQueue: JobQueue) {
     this._ethClient = ethClient;
     this._indexer = indexer;
     this._pubsub = pubsub;
     this._jobQueue = jobQueue;
-    this._baseEventWatcher = new BaseEventWatcher(upstreamConfig, this._ethClient, postgraphileClient, this._indexer, this._pubsub, this._jobQueue);
+    this._baseEventWatcher = new BaseEventWatcher(upstreamConfig, this._ethClient, this._indexer, this._pubsub, this._jobQueue);
   }
 
   getBlockProgressEventIterator (): AsyncIterator<any> {

--- a/packages/uni-info-watcher/src/fill.ts
+++ b/packages/uni-info-watcher/src/fill.ts
@@ -69,18 +69,12 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig, uniWatcher, tokenWatcher } = upstream;
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig, uniWatcher, tokenWatcher } = upstream;
 
   const cache = await getCache(cacheConfig);
 
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -99,9 +93,9 @@ export const main = async (): Promise<any> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, uniClient, erc20Client, ethClient, postgraphileClient, ethProvider, jobQueue, mode);
+  const indexer = new Indexer(db, uniClient, erc20Client, ethClient, ethProvider, jobQueue, mode);
 
-  const eventWatcher = new EventWatcher(upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
+  const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
 
   await fillBlocks(jobQueue, indexer, eventWatcher, blockDelayInMilliSecs, argv);
 };

--- a/packages/uni-info-watcher/src/fill.ts
+++ b/packages/uni-info-watcher/src/fill.ts
@@ -76,7 +76,6 @@ export const main = async (): Promise<any> => {
 
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -47,22 +47,19 @@ export class Indexer implements IndexerInterface {
   _uniClient: UniClient
   _erc20Client: ERC20Client
   _ethClient: EthClient
-  _postgraphileClient: EthClient
   _baseIndexer: BaseIndexer
   _isDemo: boolean
 
-  constructor (db: Database, uniClient: UniClient, erc20Client: ERC20Client, ethClient: EthClient, postgraphileClient: EthClient, ethProvider: providers.BaseProvider, jobQueue: JobQueue, mode: string) {
+  constructor (db: Database, uniClient: UniClient, erc20Client: ERC20Client, ethClient: EthClient, ethProvider: providers.BaseProvider, jobQueue: JobQueue, mode: string) {
     assert(db);
     assert(uniClient);
     assert(erc20Client);
-    assert(postgraphileClient);
 
     this._db = db;
     this._uniClient = uniClient;
     this._erc20Client = erc20Client;
     this._ethClient = ethClient;
-    this._postgraphileClient = postgraphileClient;
-    this._baseIndexer = new BaseIndexer(this._db, this._ethClient, this._postgraphileClient, ethProvider, jobQueue);
+    this._baseIndexer = new BaseIndexer(this._db, this._ethClient, ethProvider, jobQueue);
     this._isDemo = mode === 'demo';
   }
 

--- a/packages/uni-info-watcher/src/job-runner.ts
+++ b/packages/uni-info-watcher/src/job-runner.ts
@@ -106,7 +106,6 @@ export const main = async (): Promise<any> => {
 
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/uni-info-watcher/src/job-runner.ts
+++ b/packages/uni-info-watcher/src/job-runner.ts
@@ -93,7 +93,6 @@ export const main = async (): Promise<any> => {
     cache: cacheConfig,
     ethServer: {
       gqlApiEndpoint,
-      gqlPostgraphileEndpoint,
       rpcProviderEndpoint
     }
   } = upstream;
@@ -106,11 +105,6 @@ export const main = async (): Promise<any> => {
 
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -130,7 +124,7 @@ export const main = async (): Promise<any> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, uniClient, erc20Client, ethClient, postgraphileClient, ethProvider, jobQueue, mode);
+  const indexer = new Indexer(db, uniClient, erc20Client, ethClient, ethProvider, jobQueue, mode);
   await indexer.init();
 
   if (mode !== 'demo') {

--- a/packages/uni-info-watcher/src/server.ts
+++ b/packages/uni-info-watcher/src/server.ts
@@ -70,7 +70,6 @@ export const main = async (): Promise<any> => {
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/uni-info-watcher/test/init.ts
+++ b/packages/uni-info-watcher/test/init.ts
@@ -46,7 +46,7 @@ const main = async () => {
 
   const erc20Client = new ERC20Client(tokenWatcher);
 
-  const { ethClient, postgraphileClient, ethProvider } = await getResetConfig(config);
+  const { ethClient, ethProvider } = await getResetConfig(config);
 
   assert(jobQueueConfig, 'Missing job queue config');
   const { dbConnectionString, maxCompletionLagInSecs } = jobQueueConfig;
@@ -55,7 +55,7 @@ const main = async () => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, uniClient, erc20Client, ethClient, postgraphileClient, ethProvider, jobQueue, mode);
+  const indexer = new Indexer(db, uniClient, erc20Client, ethClient, ethProvider, jobQueue, mode);
   await indexer.init();
 
   // Get the factory contract address.

--- a/packages/uni-watcher/environments/local.toml
+++ b/packages/uni-watcher/environments/local.toml
@@ -20,7 +20,6 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
     blockDelayInMilliSecs = 2000
 

--- a/packages/uni-watcher/environments/local.toml
+++ b/packages/uni-watcher/environments/local.toml
@@ -20,7 +20,7 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
+    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
     blockDelayInMilliSecs = 2000
 

--- a/packages/uni-watcher/environments/test.toml
+++ b/packages/uni-watcher/environments/test.toml
@@ -15,7 +15,7 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:5000/graphql"
+    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8545"
     blockDelayInMilliSecs = 2000
 

--- a/packages/uni-watcher/environments/test.toml
+++ b/packages/uni-watcher/environments/test.toml
@@ -15,7 +15,6 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
-    gqlPostgraphileEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8545"
     blockDelayInMilliSecs = 2000
 

--- a/packages/uni-watcher/src/chain-pruning.test.ts
+++ b/packages/uni-watcher/src/chain-pruning.test.ts
@@ -52,7 +52,6 @@ describe('chain pruning', () => {
     const cache = await getCache(cacheConfig);
     const ethClient = new EthClient({
       gqlEndpoint: gqlApiEndpoint,
-      gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
       cache
     });
 

--- a/packages/uni-watcher/src/chain-pruning.test.ts
+++ b/packages/uni-watcher/src/chain-pruning.test.ts
@@ -45,18 +45,12 @@ describe('chain pruning', () => {
 
     // Create an Indexer object.
     assert(upstream, 'Missing upstream config');
-    const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
+    const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
     assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-    assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
 
     const cache = await getCache(cacheConfig);
     const ethClient = new EthClient({
       gqlEndpoint: gqlApiEndpoint,
-      cache
-    });
-
-    const postgraphileClient = new EthClient({
-      gqlEndpoint: gqlPostgraphileEndpoint,
       cache
     });
 
@@ -67,7 +61,7 @@ describe('chain pruning', () => {
 
     const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
 
-    indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue);
+    indexer = new Indexer(db, ethClient, ethProvider, jobQueue);
     assert(indexer, 'Could not create indexer object.');
 
     jobRunner = new JobRunner(jobQueueConfig, indexer, jobQueue);

--- a/packages/uni-watcher/src/cli/reset-cmds/state.ts
+++ b/packages/uni-watcher/src/cli/reset-cmds/state.ts
@@ -29,7 +29,7 @@ export const handler = async (argv: any): Promise<void> => {
   const config = await getConfig(argv.configFile);
   await resetJobs(config);
   const { jobQueue: jobQueueConfig } = config;
-  const { dbConfig, ethClient, postgraphileClient, ethProvider } = await getResetConfig(config);
+  const { dbConfig, ethClient, ethProvider } = await getResetConfig(config);
 
   // Initialize database.
   const db = new Database(dbConfig);
@@ -42,7 +42,7 @@ export const handler = async (argv: any): Promise<void> => {
 
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue);
 
   const syncStatus = await indexer.getSyncStatus();
   assert(syncStatus, 'Missing syncStatus');

--- a/packages/uni-watcher/src/cli/watch-contract.ts
+++ b/packages/uni-watcher/src/cli/watch-contract.ts
@@ -44,7 +44,7 @@ import { Indexer } from '../indexer';
 
   const config: Config = await getConfig(argv.configFile);
   const { database: dbConfig, jobQueue: jobQueueConfig } = config;
-  const { ethClient, postgraphileClient, ethProvider } = await getResetConfig(config);
+  const { ethClient, ethProvider } = await getResetConfig(config);
 
   assert(dbConfig);
 
@@ -59,7 +59,7 @@ import { Indexer } from '../indexer';
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue);
   await indexer.init();
 
   await indexer.watchContract(argv.address, argv.kind, argv.startingBlock);

--- a/packages/uni-watcher/src/events.ts
+++ b/packages/uni-watcher/src/events.ts
@@ -31,12 +31,12 @@ export class EventWatcher implements EventWatcherInterface {
   _jobQueue: JobQueue
   _baseEventWatcher: BaseEventWatcher
 
-  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, postgraphileClient: EthClient, indexer: Indexer, pubsub: PubSub, jobQueue: JobQueue) {
+  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, indexer: Indexer, pubsub: PubSub, jobQueue: JobQueue) {
     this._ethClient = ethClient;
     this._indexer = indexer;
     this._pubsub = pubsub;
     this._jobQueue = jobQueue;
-    this._baseEventWatcher = new BaseEventWatcher(upstreamConfig, this._ethClient, postgraphileClient, this._indexer, this._pubsub, this._jobQueue);
+    this._baseEventWatcher = new BaseEventWatcher(upstreamConfig, this._ethClient, this._indexer, this._pubsub, this._jobQueue);
   }
 
   getEventIterator (): AsyncIterator<any> {

--- a/packages/uni-watcher/src/fill.ts
+++ b/packages/uni-watcher/src/fill.ts
@@ -73,7 +73,6 @@ export const main = async (): Promise<any> => {
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/uni-watcher/src/fill.ts
+++ b/packages/uni-watcher/src/fill.ts
@@ -67,17 +67,11 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig } = upstream;
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig } = upstream;
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -93,10 +87,10 @@ export const main = async (): Promise<any> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue);
   await indexer.init();
 
-  const eventWatcher = new EventWatcher(upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
+  const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
 
   assert(jobQueueConfig, 'Missing job queue config');
 

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -38,7 +38,6 @@ type ResultEvent = {
 export class Indexer implements IndexerInterface {
   _db: Database
   _ethClient: EthClient
-  _postgraphileClient: EthClient
   _baseIndexer: BaseIndexer
   _ethProvider: ethers.providers.BaseProvider
 
@@ -46,12 +45,11 @@ export class Indexer implements IndexerInterface {
   _poolContract: ethers.utils.Interface
   _nfpmContract: ethers.utils.Interface
 
-  constructor (db: Database, ethClient: EthClient, postgraphileClient: EthClient, ethProvider: ethers.providers.BaseProvider, jobQueue: JobQueue) {
+  constructor (db: Database, ethClient: EthClient, ethProvider: ethers.providers.BaseProvider, jobQueue: JobQueue) {
     this._db = db;
     this._ethClient = ethClient;
-    this._postgraphileClient = postgraphileClient;
     this._ethProvider = ethProvider;
-    this._baseIndexer = new BaseIndexer(this._db, this._ethClient, this._postgraphileClient, this._ethProvider, jobQueue);
+    this._baseIndexer = new BaseIndexer(this._db, this._ethClient, this._ethProvider, jobQueue);
 
     this._factoryContract = new ethers.utils.Interface(factoryABI);
     this._poolContract = new ethers.utils.Interface(poolABI);
@@ -444,7 +442,7 @@ export class Indexer implements IndexerInterface {
 
     console.time('time:indexer#_fetchAndSaveEvents-get-logs-txs');
     const logsPromise = this._ethClient.getLogs({ blockHash });
-    const transactionsPromise = this._postgraphileClient.getBlockWithTransactions({ blockHash });
+    const transactionsPromise = this._ethClient.getBlockWithTransactions({ blockHash });
 
     const [
       { logs },

--- a/packages/uni-watcher/src/job-runner.ts
+++ b/packages/uni-watcher/src/job-runner.ts
@@ -81,18 +81,12 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -106,7 +100,7 @@ export const main = async (): Promise<any> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue);
   await indexer.init();
 
   const jobRunner = new JobRunner(jobQueueConfig, indexer, jobQueue);

--- a/packages/uni-watcher/src/job-runner.ts
+++ b/packages/uni-watcher/src/job-runner.ts
@@ -88,7 +88,6 @@ export const main = async (): Promise<any> => {
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/uni-watcher/src/server.ts
+++ b/packages/uni-watcher/src/server.ts
@@ -58,7 +58,6 @@ export const main = async (): Promise<any> => {
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/uni-watcher/src/server.ts
+++ b/packages/uni-watcher/src/server.ts
@@ -51,18 +51,12 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -80,10 +74,10 @@ export const main = async (): Promise<any> => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue);
   await indexer.init();
 
-  const eventWatcher = new EventWatcher(upstream, ethClient, postgraphileClient, indexer, pubsub, jobQueue);
+  const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
   await eventWatcher.start();
 
   const resolvers = process.env.MOCK ? await createMockResolvers() : await createResolvers(indexer, eventWatcher);

--- a/packages/uni-watcher/src/smoke.test.ts
+++ b/packages/uni-watcher/src/smoke.test.ts
@@ -92,7 +92,6 @@ describe('uni-watcher', () => {
     const cache = await getCache(cacheConfig);
     ethClient = new EthClient({
       gqlEndpoint: gqlApiEndpoint,
-      gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
       cache
     });
 

--- a/packages/uni-watcher/src/smoke.test.ts
+++ b/packages/uni-watcher/src/smoke.test.ts
@@ -64,7 +64,6 @@ describe('uni-watcher', () => {
   let db: Database;
   let uniClient: UniClient;
   let ethClient: EthClient;
-  let postgraphileClient: EthClient;
   let ethProvider: ethers.providers.JsonRpcProvider;
   let jobQueue: JobQueue;
   let signer: Signer;
@@ -80,9 +79,8 @@ describe('uni-watcher', () => {
     assert(host, 'Missing host.');
     assert(port, 'Missing port.');
 
-    const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
+    const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
     assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint.');
-    assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint.');
     assert(rpcProviderEndpoint, 'Missing upstream ethServer.rpcProviderEndpoint.');
     assert(cacheConfig, 'Missing dbConfig.');
 
@@ -92,11 +90,6 @@ describe('uni-watcher', () => {
     const cache = await getCache(cacheConfig);
     ethClient = new EthClient({
       gqlEndpoint: gqlApiEndpoint,
-      cache
-    });
-
-    postgraphileClient = new EthClient({
-      gqlEndpoint: gqlPostgraphileEndpoint,
       cache
     });
 
@@ -134,7 +127,7 @@ describe('uni-watcher', () => {
     factory = new Contract(factoryContract.address, FACTORY_ABI, signer);
 
     // Verifying with the db.
-    const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue);
+    const indexer = new Indexer(db, ethClient, ethProvider, jobQueue);
     await indexer.init();
     assert(await indexer.isWatchedContract(factory.address), 'Factory contract not added to the database.');
   });
@@ -270,7 +263,7 @@ describe('uni-watcher', () => {
     nfpm = new Contract(nfpmContract.address, NFPM_ABI, signer);
 
     // Verifying with the db.
-    const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue);
+    const indexer = new Indexer(db, ethClient, ethProvider, jobQueue);
     await indexer.init();
     assert(await indexer.isWatchedContract(nfpm.address), 'NFPM contract not added to the database.');
   });

--- a/packages/uni-watcher/test/init.ts
+++ b/packages/uni-watcher/test/init.ts
@@ -57,7 +57,7 @@ const main = async () => {
   assert(host, 'Missing host.');
   assert(port, 'Missing port.');
 
-  const { ethClient, postgraphileClient, ethProvider } = await getResetConfig(config);
+  const { ethClient, ethProvider } = await getResetConfig(config);
 
   // Initialize uniClient.
   const endpoint = `http://${host}:${port}/graphql`;
@@ -81,7 +81,7 @@ const main = async () => {
   const jobQueue = new JobQueue({ dbConnectionString, maxCompletionLag: maxCompletionLagInSecs });
   await jobQueue.start();
 
-  const indexer = new Indexer(db, ethClient, postgraphileClient, ethProvider, jobQueue);
+  const indexer = new Indexer(db, ethClient, ethProvider, jobQueue);
 
   let factory: Contract;
   // Checking whether factory is deployed.

--- a/packages/util/src/cli/check-config.ts
+++ b/packages/util/src/cli/check-config.ts
@@ -23,7 +23,7 @@ const main = async () => {
     }
   }).argv;
 
-  const { upstream: { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint } } } = await getConfig(argv.configFile);
+  const { upstream: { ethServer: { gqlApiEndpoint, rpcProviderEndpoint } } } = await getConfig(argv.configFile);
 
   // Get latest block in chain using ipld-eth-server GQL.
   log(`Checking ipld-eth-server GQL endpoint ${gqlApiEndpoint}`);
@@ -32,19 +32,10 @@ const main = async () => {
   assert(currentBlock && currentBlock.number);
   log('ipld-eth-server GQL endpoint working');
 
-  // Get block by number using postgraphile.
-  log(`Checking postgraphile GQL endpoint ${gqlPostgraphileEndpoint}`);
-  const postgraphileClient = new EthClient({ gqlEndpoint: gqlPostgraphileEndpoint, cache: undefined });
-  const { allEthHeaderCids: { nodes } } = await postgraphileClient.getBlocks({ blockNumber: currentBlock.number });
-  assert(nodes.length);
-  const [{ blockHash }] = nodes;
-  assert(blockHash === currentBlock.hash);
-  log('postgraphile GQL endpoint working');
-
   // Get block by hash using RPC endpoint.
   log(`Checking RPC endpoint ${rpcProviderEndpoint}`);
   const ethProvider = getCustomProvider(rpcProviderEndpoint);
-  const ethBlock = await ethProvider.getBlock(blockHash);
+  const ethBlock = await ethProvider.getBlock(currentBlock.hash);
   assert(ethBlock.number === currentBlock.number);
   log('RPC endpoint working');
 };

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -63,9 +63,9 @@ export const processBlockByNumber = async (
     });
 
     if (!blocks.length) {
-      console.time('time:common#processBlockByNumber-postgraphile');
+      console.time('time:common#processBlockByNumber-ipld-eth-server');
       blocks = await indexer.getBlocks({ blockNumber });
-      console.timeEnd('time:common#processBlockByNumber-postgraphile');
+      console.timeEnd('time:common#processBlockByNumber-ipld-eth-server');
     }
 
     if (blocks.length) {

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -101,7 +101,6 @@ export const getResetConfig = async (config: Config): Promise<{
 
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    gqlSubscriptionEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -42,7 +42,6 @@ export interface UpstreamConfig {
   cache: CacheConfig,
   ethServer: {
     gqlApiEndpoint: string;
-    gqlPostgraphileEndpoint: string;
     rpcProviderEndpoint: string;
     blockDelayInMilliSecs: number;
   }
@@ -83,7 +82,6 @@ export const getResetConfig = async (config: Config): Promise<{
   serverConfig: ServerConfig,
   upstreamConfig: UpstreamConfig,
   ethClient: EthClient,
-  postgraphileClient: EthClient,
   ethProvider: BaseProvider
 }> => {
   const { database: dbConfig, upstream: upstreamConfig, server: serverConfig } = config;
@@ -92,20 +90,14 @@ export const getResetConfig = async (config: Config): Promise<{
   assert(dbConfig, 'Missing database config');
 
   assert(upstreamConfig, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, gqlPostgraphileEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstreamConfig;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstreamConfig;
   assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint');
-  assert(gqlPostgraphileEndpoint, 'Missing upstream ethServer.gqlPostgraphileEndpoint');
   assert(rpcProviderEndpoint, 'Missing upstream ethServer.rpcProviderEndpoint');
 
   const cache = await getCache(cacheConfig);
 
   const ethClient = new EthClient({
     gqlEndpoint: gqlApiEndpoint,
-    cache
-  });
-
-  const postgraphileClient = new EthClient({
-    gqlEndpoint: gqlPostgraphileEndpoint,
     cache
   });
 
@@ -116,7 +108,6 @@ export const getResetConfig = async (config: Config): Promise<{
     serverConfig,
     upstreamConfig,
     ethClient,
-    postgraphileClient,
     ethProvider
   };
 };

--- a/packages/util/src/events.ts
+++ b/packages/util/src/events.ts
@@ -21,17 +21,15 @@ export const BlockProgressEvent = 'block-progress-event';
 
 export class EventWatcher {
   _ethClient: EthClient
-  _postgraphileClient: EthClient
   _indexer: IndexerInterface
   _subscription?: ZenObservable.Subscription
   _pubsub: PubSub
   _jobQueue: JobQueue
   _upstreamConfig: UpstreamConfig
 
-  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, postgraphileClient: EthClient, indexer: IndexerInterface, pubsub: PubSub, jobQueue: JobQueue) {
+  constructor (upstreamConfig: UpstreamConfig, ethClient: EthClient, indexer: IndexerInterface, pubsub: PubSub, jobQueue: JobQueue) {
     this._upstreamConfig = upstreamConfig;
     this._ethClient = ethClient;
-    this._postgraphileClient = postgraphileClient;
     this._indexer = indexer;
     this._pubsub = pubsub;
     this._jobQueue = jobQueue;

--- a/packages/util/src/indexer.ts
+++ b/packages/util/src/indexer.ts
@@ -29,17 +29,15 @@ export interface ValueResult {
 export class Indexer {
   _db: DatabaseInterface;
   _ethClient: EthClient;
-  _postgraphileClient: EthClient;
   _getStorageAt: GetStorageAt;
   _ethProvider: ethers.providers.BaseProvider;
   _jobQueue: JobQueue;
 
   _watchedContracts: { [key: string]: ContractInterface } = {};
 
-  constructor (db: DatabaseInterface, ethClient: EthClient, postgraphileClient: EthClient, ethProvider: ethers.providers.BaseProvider, jobQueue: JobQueue) {
+  constructor (db: DatabaseInterface, ethClient: EthClient, ethProvider: ethers.providers.BaseProvider, jobQueue: JobQueue) {
     this._db = db;
     this._ethClient = ethClient;
-    this._postgraphileClient = postgraphileClient;
     this._ethProvider = ethProvider;
     this._jobQueue = jobQueue;
     this._getStorageAt = this._ethClient.getStorageAt.bind(this._ethClient);
@@ -127,7 +125,7 @@ export class Indexer {
 
   async getBlocks (blockFilter: { blockNumber?: number, blockHash?: string }): Promise<any> {
     assert(blockFilter.blockHash || blockFilter.blockNumber);
-    const result = await this._postgraphileClient.getBlocks(blockFilter);
+    const result = await this._ethClient.getBlocks(blockFilter);
     const { allEthHeaderCids: { nodes: blocks } } = result;
 
     if (!blocks.length) {


### PR DESCRIPTION
Part of https://github.com/vulcanize/ops/issues/154

- Point to ipld-eth-server GraphQL server, deprecating postgraphile
- Remove old postgraphile subcription queries from ipld-eth-client
- Remove postgraphile client and config option from watchers