### PR TITLE
Add prometheus metrics to monitor watcher progress and GQL queries

### DIFF
--- a/packages/erc20-watcher/environments/local.toml
+++ b/packages/erc20-watcher/environments/local.toml
@@ -4,6 +4,11 @@
   mode = "eth_call"
   kind = "lazy"
 
+[metrics]
+  host = "127.0.0.1"
+    [metrics.gql]
+    port = 9000
+
 [database]
   type = "postgres"
   host = "localhost"

--- a/packages/erc20-watcher/environments/local.toml
+++ b/packages/erc20-watcher/environments/local.toml
@@ -6,8 +6,9 @@
 
 [metrics]
   host = "127.0.0.1"
+  port = 9000
     [metrics.gql]
-    port = 9000
+    port = 9001
 
 [database]
   type = "postgres"

--- a/packages/erc20-watcher/src/job-runner.ts
+++ b/packages/erc20-watcher/src/job-runner.ts
@@ -18,7 +18,8 @@ import {
   QUEUE_EVENT_PROCESSING,
   JobQueueConfig,
   DEFAULT_CONFIG_PATH,
-  getCustomProvider
+  getCustomProvider,
+  startMetricsServer
 } from '@vulcanize/util';
 
 import { Indexer } from './indexer';
@@ -103,6 +104,8 @@ export const main = async (): Promise<any> => {
 
   const jobRunner = new JobRunner(jobQueueConfig, indexer, jobQueue);
   await jobRunner.start();
+
+  await startMetricsServer(config, indexer);
 };
 
 main().then(() => {

--- a/packages/erc20-watcher/src/resolvers.ts
+++ b/packages/erc20-watcher/src/resolvers.ts
@@ -6,7 +6,7 @@ import assert from 'assert';
 import BigInt from 'apollo-type-bigint';
 import debug from 'debug';
 
-import { ValueResult } from '@vulcanize/util';
+import { ValueResult, gqlTotalQueryCount, gqlQueryCount } from '@vulcanize/util';
 
 import { Indexer } from './indexer';
 import { EventWatcher } from './events';
@@ -46,36 +46,56 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       totalSupply: (_: any, { blockHash, token }: { blockHash: string, token: string }): Promise<ValueResult> => {
         log('totalSupply', blockHash, token);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('totalSupply').inc(1);
+
         return indexer.totalSupply(blockHash, token);
       },
 
       balanceOf: async (_: any, { blockHash, token, owner }: { blockHash: string, token: string, owner: string }) => {
         log('balanceOf', blockHash, token, owner);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('balanceOf').inc(1);
+
         return indexer.balanceOf(blockHash, token, owner);
       },
 
       allowance: async (_: any, { blockHash, token, owner, spender }: { blockHash: string, token: string, owner: string, spender: string }) => {
         log('allowance', blockHash, token, owner, spender);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('allowance').inc(1);
+
         return indexer.allowance(blockHash, token, owner, spender);
       },
 
       name: (_: any, { blockHash, token }: { blockHash: string, token: string }) => {
         log('name', blockHash, token);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('name').inc(1);
+
         return indexer.name(blockHash, token);
       },
 
       symbol: (_: any, { blockHash, token }: { blockHash: string, token: string }) => {
         log('symbol', blockHash, token);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('symbol').inc(1);
+
         return indexer.symbol(blockHash, token);
       },
 
       decimals: (_: any, { blockHash, token }: { blockHash: string, token: string }) => {
         log('decimals', blockHash, token);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('decimals').inc(1);
+
         return indexer.decimals(blockHash, token);
       },
 
       events: async (_: any, { blockHash, token, name }: { blockHash: string, token: string, name: string }) => {
         log('events', blockHash, token, name || '');
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('events').inc(1);
 
         const block = await indexer.getBlockProgress(blockHash);
         if (!block || !block.isComplete) {
@@ -88,6 +108,8 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       eventsInRange: async (_: any, { fromBlockNumber, toBlockNumber }: { fromBlockNumber: number, toBlockNumber: number }) => {
         log('eventsInRange', fromBlockNumber, toBlockNumber);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('eventsInRange').inc(1);
 
         const { expected, actual } = await indexer.getProcessedBlockCountForRange(fromBlockNumber, toBlockNumber);
         if (expected !== actual) {

--- a/packages/erc20-watcher/src/server.ts
+++ b/packages/erc20-watcher/src/server.ts
@@ -14,7 +14,7 @@ import { createServer } from 'http';
 
 import { getCache } from '@vulcanize/cache';
 import { EthClient } from '@vulcanize/ipld-eth-client';
-import { DEFAULT_CONFIG_PATH, getConfig, getCustomProvider, JobQueue, KIND_ACTIVE } from '@vulcanize/util';
+import { DEFAULT_CONFIG_PATH, getConfig, getCustomProvider, JobQueue, KIND_ACTIVE, startGQLMetricsServer } from '@vulcanize/util';
 
 import typeDefs from './schema';
 
@@ -99,6 +99,8 @@ export const main = async (): Promise<any> => {
   httpServer.listen(port, host, () => {
     log(`Server is listening on host ${host} port ${port}`);
   });
+
+  await startGQLMetricsServer(config);
 
   return { app, server };
 };

--- a/packages/uni-info-watcher/environments/local.toml
+++ b/packages/uni-info-watcher/environments/local.toml
@@ -7,9 +7,9 @@
 
 [metrics]
   host = "127.0.0.1"
-  port = 9003
+  port = 9004
     [metrics.gql]
-    port = 9004
+    port = 9005
 
 [database]
   type = "postgres"

--- a/packages/uni-info-watcher/environments/local.toml
+++ b/packages/uni-info-watcher/environments/local.toml
@@ -7,7 +7,9 @@
 
 [metrics]
   host = "127.0.0.1"
-  port = 8084
+  port = 9003
+    [metrics.gql]
+    port = 9004
 
 [database]
   type = "postgres"

--- a/packages/uni-info-watcher/src/job-runner.ts
+++ b/packages/uni-info-watcher/src/job-runner.ts
@@ -134,7 +134,7 @@ export const main = async (): Promise<any> => {
   const jobRunner = new JobRunner(jobQueueConfig, indexer, jobQueue);
   await jobRunner.start();
 
-  await startMetricsServer(metrics);
+  await startMetricsServer(config, indexer);
 };
 
 main().then(() => {

--- a/packages/uni-info-watcher/src/resolvers.ts
+++ b/packages/uni-info-watcher/src/resolvers.ts
@@ -7,7 +7,7 @@ import BigInt from 'apollo-type-bigint';
 import debug from 'debug';
 import { GraphQLScalarType } from 'graphql';
 
-import { BlockHeight, GraphDecimal, OrderDirection } from '@vulcanize/util';
+import { BlockHeight, gqlQueryCount, gqlTotalQueryCount, GraphDecimal, OrderDirection } from '@vulcanize/util';
 
 import { Indexer } from './indexer';
 import { Burn } from './entity/Burn';
@@ -64,18 +64,24 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
     Query: {
       bundle: async (_: any, { id, block = {} }: { id: string, block: BlockHeight }) => {
         log('bundle', id, block);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('bundle').inc(1);
 
         return indexer.getBundle(id, block);
       },
 
       bundles: async (_: any, { block = {}, first }: { first: number, block: BlockHeight }) => {
         log('bundles', block, first);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('bundles').inc(1);
 
         return indexer.getEntities(Bundle, block, {}, { limit: first });
       },
 
       burns: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('burns', first, orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('burns').inc(1);
 
         return indexer.getEntities(
           Burn,
@@ -111,12 +117,16 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       factories: async (_: any, { block = {}, first }: { first: number, block: BlockHeight }) => {
         log('factories', block, first);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('factories').inc(1);
 
         return indexer.getEntities(Factory, block, {}, { limit: first });
       },
 
       mints: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('mints', first, orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('mints').inc(1);
 
         return indexer.getEntities(
           Mint,
@@ -152,18 +162,24 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       pool: async (_: any, { id, block = {} }: { id: string, block: BlockHeight }) => {
         log('pool', id, block);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('pool').inc(1);
 
         return indexer.getPool(id, block);
       },
 
       poolDayDatas: async (_: any, { block = {}, first, skip, orderBy, orderDirection, where }: { block: BlockHeight, first: number, skip: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('poolDayDatas', first, skip, orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('poolDayDatas').inc(1);
 
         return indexer.getEntities(PoolDayData, block, where, { limit: first, skip, orderBy, orderDirection });
       },
 
       pools: async (_: any, { block = {}, first, orderBy, orderDirection, where = {} }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('pools', block, first, orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('pools').inc(1);
 
         return indexer.getEntities(
           Pool,
@@ -187,6 +203,8 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       swaps: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('swaps', first, orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('swaps').inc(1);
 
         return indexer.getEntities(
           Swap,
@@ -222,18 +240,24 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       ticks: async (_: any, { block = {}, first, skip, where = {} }: { block: BlockHeight, first: number, skip: number, where: { [key: string]: any } }) => {
         log('ticks', block, first, skip, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('ticks').inc(1);
 
         return indexer.getEntities(Tick, block, where, { limit: first, skip });
       },
 
       token: async (_: any, { id, block = {} }: { id: string, block: BlockHeight }) => {
         log('token', id, block);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('token').inc(1);
 
         return indexer.getToken(id, block);
       },
 
       tokens: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('tokens', orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('tokens').inc(1);
 
         return indexer.getEntities(
           Token,
@@ -252,18 +276,24 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       tokenDayDatas: async (_: any, { block = {}, first, skip, orderBy, orderDirection, where }: { block: BlockHeight, first: number, skip: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('tokenDayDatas', first, skip, orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('tokenDayDatas').inc(1);
 
         return indexer.getEntities(TokenDayData, block, where, { limit: first, skip, orderBy, orderDirection });
       },
 
       tokenHourDatas: async (_: any, { block = {}, first, skip, orderBy, orderDirection, where }: { block: BlockHeight, first: number, skip: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('tokenHourDatas', first, skip, orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('tokenHourDatas').inc(1);
 
         return indexer.getEntities(TokenHourData, block, where, { limit: first, skip, orderBy, orderDirection });
       },
 
       transactions: async (_: any, { block = {}, first, orderBy, orderDirection, where }: { block: BlockHeight, first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('transactions', first, orderBy, orderDirection);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('transactions').inc(1);
 
         return indexer.getEntities(
           Transaction,
@@ -367,12 +397,16 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       uniswapDayDatas: async (_: any, { block = {}, first, skip, orderBy, orderDirection, where }: { block: BlockHeight, first: number, skip: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('uniswapDayDatas', first, skip, orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('uniswapDayDatas').inc(1);
 
         return indexer.getEntities(UniswapDayData, block, where, { limit: first, skip, orderBy, orderDirection });
       },
 
       positions: async (_: any, { block = {}, first, where }: { block: BlockHeight, first: number, where: { [key: string]: any } }) => {
         log('positions', first, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('positions').inc(1);
 
         return indexer.getEntities(
           Position,
@@ -416,12 +450,16 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       blocks: async (_: any, { first, orderBy, orderDirection, where }: { first: number, orderBy: string, orderDirection: OrderDirection, where: { [key: string]: any } }) => {
         log('blocks', first, orderBy, orderDirection, where);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('blocks').inc(1);
 
         return indexer.getBlockEntities(where, { limit: first, orderBy, orderDirection });
       },
 
       indexingStatusForCurrentVersion: async (_: any, { subgraphName }: { subgraphName: string }) => {
         log('health', subgraphName);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('indexingStatusForCurrentVersion').inc(1);
 
         return indexer.getIndexingStatus();
       }

--- a/packages/uni-info-watcher/src/server.ts
+++ b/packages/uni-info-watcher/src/server.ts
@@ -15,7 +15,7 @@ import { createServer } from 'http';
 import { Client as ERC20Client } from '@vulcanize/erc20-watcher';
 import { Client as UniClient } from '@vulcanize/uni-watcher';
 import { EthClient } from '@vulcanize/ipld-eth-client';
-import { DEFAULT_CONFIG_PATH, getConfig, getCustomProvider, JobQueue } from '@vulcanize/util';
+import { DEFAULT_CONFIG_PATH, getConfig, getCustomProvider, JobQueue, startGQLMetricsServer } from '@vulcanize/util';
 import { getCache } from '@vulcanize/cache';
 
 import typeDefs from './schema';
@@ -106,6 +106,8 @@ export const main = async (): Promise<any> => {
   httpServer.listen(port, host, () => {
     log(`Server is listening on host ${host} port ${port}`);
   });
+
+  await startGQLMetricsServer(config);
 
   return { app, server };
 };

--- a/packages/uni-watcher/environments/local.toml
+++ b/packages/uni-watcher/environments/local.toml
@@ -4,7 +4,9 @@
 
 [metrics]
   host = "127.0.0.1"
-  port = 8083
+  port = 9001
+    [metrics.gql]
+    port = 9002
 
 [database]
   type = "postgres"

--- a/packages/uni-watcher/environments/local.toml
+++ b/packages/uni-watcher/environments/local.toml
@@ -4,9 +4,9 @@
 
 [metrics]
   host = "127.0.0.1"
-  port = 9001
+  port = 9002
     [metrics.gql]
-    port = 9002
+    port = 9003
 
 [database]
   type = "postgres"

--- a/packages/uni-watcher/src/job-runner.ts
+++ b/packages/uni-watcher/src/job-runner.ts
@@ -73,7 +73,7 @@ export const main = async (): Promise<any> => {
 
   assert(config.server, 'Missing server config');
 
-  const { upstream, database: dbConfig, jobQueue: jobQueueConfig, metrics } = config;
+  const { upstream, database: dbConfig, jobQueue: jobQueueConfig } = config;
 
   assert(dbConfig, 'Missing database config');
 
@@ -106,7 +106,7 @@ export const main = async (): Promise<any> => {
   const jobRunner = new JobRunner(jobQueueConfig, indexer, jobQueue);
   await jobRunner.start();
 
-  startMetricsServer(metrics);
+  await startMetricsServer(config, indexer);
 };
 
 main().then(() => {

--- a/packages/uni-watcher/src/resolvers.ts
+++ b/packages/uni-watcher/src/resolvers.ts
@@ -8,7 +8,7 @@ import debug from 'debug';
 
 import { Indexer } from './indexer';
 import { EventWatcher } from './events';
-import { ValueResult } from '@vulcanize/util';
+import { ValueResult, gqlTotalQueryCount, gqlQueryCount } from '@vulcanize/util';
 
 const log = debug('vulcanize:resolver');
 
@@ -56,6 +56,8 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       events: async (_: any, { blockHash, contract, name }: { blockHash: string, contract: string, name: string }) => {
         log('events', blockHash, contract, name || '');
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('events').inc(1);
 
         const block = await indexer.getBlockProgress(blockHash);
         if (!block || !block.isComplete) {
@@ -69,6 +71,8 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       eventsInRange: async (_: any, { fromBlockNumber, toBlockNumber }: { fromBlockNumber: number, toBlockNumber: number }) => {
         log('eventsInRange', fromBlockNumber, toBlockNumber);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('eventsInRange').inc(1);
 
         const { expected, actual } = await indexer.getProcessedBlockCountForRange(fromBlockNumber, toBlockNumber);
         if (expected !== actual) {
@@ -81,31 +85,49 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
 
       position: (_: any, { blockHash, tokenId }: { blockHash: string, tokenId: string }) => {
         log('position', blockHash, tokenId);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('position').inc(1);
+
         return indexer.position(blockHash, tokenId);
       },
 
       positions: (_: any, { blockHash, contractAddress, tokenId }: { blockHash: string, contractAddress: string, tokenId: string }): Promise<ValueResult> => {
         log('positions', blockHash, contractAddress, tokenId);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('positions').inc(1);
+
         return indexer.positions(blockHash, contractAddress, tokenId);
       },
 
       poolIdToPoolKey: (_: any, { blockHash, poolId }: { blockHash: string, poolId: string }) => {
         log('poolIdToPoolKey', blockHash, poolId);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('poolIdToPoolKey').inc(1);
+
         return indexer.poolIdToPoolKey(blockHash, poolId);
       },
 
       getPool: (_: any, { blockHash, token0, token1, fee }: { blockHash: string, token0: string, token1: string, fee: string }) => {
         log('getPool', blockHash, token0, token1, fee);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('getPool').inc(1);
+
         return indexer.getPool(blockHash, token0, token1, fee);
       },
 
       callGetPool: (_: any, { blockHash, contractAddress, key0, key1, key2 }: { blockHash: string, contractAddress: string, key0: string, key1: string, key2: number }): Promise<ValueResult> => {
         log('callGetPool', blockHash, contractAddress, key0, key1, key2);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('callGetPool').inc(1);
+
         return indexer.callGetPool(blockHash, contractAddress, key0, key1, key2);
       },
 
       getContract: (_: any, { type }: { type: string }) => {
         log('getContract', type);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('getContract').inc(1);
+
         return indexer.getContract(type);
       }
     }

--- a/packages/uni-watcher/src/server.ts
+++ b/packages/uni-watcher/src/server.ts
@@ -14,7 +14,7 @@ import { createServer } from 'http';
 
 import { getCache } from '@vulcanize/cache';
 import { EthClient } from '@vulcanize/ipld-eth-client';
-import { DEFAULT_CONFIG_PATH, getConfig, getCustomProvider, JobQueue } from '@vulcanize/util';
+import { DEFAULT_CONFIG_PATH, getConfig, getCustomProvider, JobQueue, startGQLMetricsServer } from '@vulcanize/util';
 
 import typeDefs from './schema';
 
@@ -97,6 +97,8 @@ export const main = async (): Promise<any> => {
   httpServer.listen(port, host, () => {
     log(`Server is listening on host ${host} port ${port}`);
   });
+
+  await startGQLMetricsServer(config);
 
   return { app, server };
 };

--- a/packages/util/index.ts
+++ b/packages/util/index.ts
@@ -14,3 +14,4 @@ export * from './src/indexer';
 export * from './src/job-runner';
 export * from './src/graph-decimal';
 export * from './src/metrics';
+export * from './src/gql-metrics';

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -87,7 +87,7 @@ export const processBlockByNumber = async (
         }
       }
 
-      await indexer.updateSyncStatusChainHead(blocks[0].blockHash, blocks[0].blockNumber);
+      await indexer.updateSyncStatusChainHead(blocks[0].blockHash, Number(blocks[0].blockNumber));
 
       return;
     }

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -33,9 +33,14 @@ interface ServerConfig {
   kind: string;
 }
 
+export interface GQLMetricsConfig {
+  port: number;
+}
+
 export interface MetricsConfig {
   host: string;
   port: number;
+  gql: GQLMetricsConfig;
 }
 
 export interface UpstreamConfig {

--- a/packages/util/src/gql-metrics.ts
+++ b/packages/util/src/gql-metrics.ts
@@ -1,0 +1,51 @@
+//
+// Copyright 2022 Vulcanize, Inc.
+//
+
+import * as client from 'prom-client';
+import express, { Application } from 'express';
+import debug from 'debug';
+import assert from 'assert';
+
+import { Config } from './config';
+
+const log = debug('vulcanize:gql-metrics');
+
+const gqlRegistry = new client.Registry();
+
+// Create custom metrics
+export const gqlTotalQueryCount = new client.Counter({
+  name: 'gql_query_count_total',
+  help: 'Total GQL queries made',
+  registers: [gqlRegistry]
+});
+
+export const gqlQueryCount = new client.Counter({
+  name: 'gql_query_count',
+  help: 'GQL queries made',
+  labelNames: ['name'] as const,
+  registers: [gqlRegistry]
+});
+
+// Export metrics on a server
+const app: Application = express();
+
+export const startGQLMetricsServer = async (config: Config): Promise<void> => {
+  if (!config.metrics || !config.metrics.gql) {
+    log('GQL metrics disabled. To enable add GQL metrics host and port.');
+    return;
+  }
+
+  assert(config.metrics.host, 'Missing config for metrics host');
+  assert(config.metrics.gql.port, 'Missing config for gql metrics port');
+
+  app.get('/metrics', async (req, res) => {
+    res.setHeader('Content-Type', gqlRegistry.contentType);
+    const metrics = await gqlRegistry.metrics();
+    res.send(metrics);
+  });
+
+  app.listen(config.metrics.gql.port, config.metrics.host, () => {
+    log(`GQL Metrics exposed at http://${config.metrics.host}:${config.metrics.gql.port}/metrics`);
+  });
+};

--- a/packages/util/src/job-queue.ts
+++ b/packages/util/src/job-queue.ts
@@ -6,6 +6,8 @@ import assert from 'assert';
 import debug from 'debug';
 import PgBoss from 'pg-boss';
 
+import { jobCount, lastJobCompletedOn } from './metrics';
+
 interface Config {
   dbConnectionString: string
   maxCompletionLag: number
@@ -41,10 +43,35 @@ export class JobQueue {
 
       deleteAfterHours: 1, // 1 hour
 
-      newJobCheckInterval: 100
+      newJobCheckInterval: 100,
+
+      // Time interval for firing monitor-states event.
+      monitorStateIntervalSeconds: 10
     });
 
     this._boss.on('error', error => log(error));
+
+    this._boss.on('monitor-states', monitorStates => {
+      jobCount.set({ state: 'all' }, monitorStates.all);
+      jobCount.set({ state: 'created' }, monitorStates.created);
+      jobCount.set({ state: 'retry' }, monitorStates.retry);
+      jobCount.set({ state: 'active' }, monitorStates.active);
+      jobCount.set({ state: 'completed' }, monitorStates.completed);
+      jobCount.set({ state: 'expired' }, monitorStates.expired);
+      jobCount.set({ state: 'cancelled' }, monitorStates.cancelled);
+      jobCount.set({ state: 'failed' }, monitorStates.failed);
+
+      Object.entries(monitorStates.queues).forEach(([name, counts]) => {
+        jobCount.set({ state: 'all', name }, counts.all);
+        jobCount.set({ state: 'created', name }, counts.created);
+        jobCount.set({ state: 'retry', name }, counts.retry);
+        jobCount.set({ state: 'active', name }, counts.active);
+        jobCount.set({ state: 'completed', name }, counts.completed);
+        jobCount.set({ state: 'expired', name }, counts.expired);
+        jobCount.set({ state: 'cancelled', name }, counts.cancelled);
+        jobCount.set({ state: 'failed', name }, counts.failed);
+      });
+    });
   }
 
   get maxCompletionLag (): number {
@@ -70,6 +97,7 @@ export class JobQueue {
         try {
           log(`Processing queue ${queue} job ${job.id}...`);
           await callback(job);
+          lastJobCompletedOn.setToCurrentTime({ name: queue });
         } catch (error) {
           log(`Error in queue ${queue} job ${job.id}`);
           log(error);

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -280,6 +280,8 @@ export class JobRunner {
     const { subgraphEventsOrder = false } = this._jobQueueConfig;
     const unwatchedContractEvents: EventInterface[] = [];
 
+    // In subgraph, events from contract created in the same block are processed after all other events.
+    // Divide the events into watched | unwatched contract events.
     if (subgraphEventsOrder) {
       // Processing events out of order causes issue with restarts/kill at arbitrary times.
       // Events of contract, added to watch in processing an event, may not be processed at end after restart/kill.
@@ -352,6 +354,8 @@ export class JobRunner {
 
     if (subgraphEventsOrder) {
       // Process events from contracts not watched initially.
+      // Note: events not "unknown" even if for unwatched contracts.
+      // (uni-watcher has already parsed the events for unwatched contracts)
       for (const dbEvent of unwatchedContractEvents) {
         const watchedContract = this._indexer.isWatchedContract(dbEvent.contract);
 

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -12,7 +12,7 @@ import { JobQueue } from './job-queue';
 import { EventInterface, IndexerInterface, SyncStatusInterface } from './types';
 import { wait } from './misc';
 import { createPruningJob } from './common';
-import { lastProcessedBlock, lastBlockProcessDuration, lastBlockNumEvents } from './metrics';
+import { lastBlockNumEvents, lastBlockProcessDuration, lastProcessedBlockNumber } from './metrics';
 
 const log = debug('vulcanize:job-runner');
 
@@ -130,7 +130,7 @@ export class JobRunner {
       log(`Total block process time (${blockNumber - 1}): ${blockProcessDuration}ms`);
 
       // Update metrics
-      lastProcessedBlock.set(blockNumber - 1);
+      lastProcessedBlockNumber.set(blockNumber - 1);
       lastBlockProcessDuration.set(blockProcessDuration);
       lastBlockNumEvents.set(this._blockNumEvents);
     }

--- a/packages/util/src/metrics.ts
+++ b/packages/util/src/metrics.ts
@@ -112,7 +112,7 @@ const registerDBSizeMetrics = async ({ database, jobQueue }: Config): Promise<vo
   // eslint-disable-next-line no-new
   new promClient.Gauge({
     name: 'database_size_bytes',
-    help: 'Total entries in event table',
+    help: 'Watcher database sizes in bytes',
     labelNames: ['type'] as const,
     async collect () {
       const [

--- a/packages/util/src/metrics.ts
+++ b/packages/util/src/metrics.ts
@@ -1,39 +1,83 @@
 import promClient, { register } from 'prom-client';
 import express, { Application } from 'express';
+import { createConnection } from 'typeorm';
 import debug from 'debug';
 import assert from 'assert';
 
-import { MetricsConfig } from './config';
+import { Config } from './config';
+import { IndexerInterface } from './types';
+
+const DB_SIZE_QUERY = 'SELECT pg_database_size(current_database())';
 
 const log = debug('vulcanize:metrics');
 
 // Create custom metrics
-export const lastProcessedBlock = new promClient.Gauge({
-  name: 'last_processed_block',
-  help: 'Last processed block'
+export const jobCount = new promClient.Gauge({
+  name: 'pgboss_jobs_total',
+  help: 'Total entries in job table',
+  labelNames: ['state', 'name'] as const
+});
+
+export const lastJobCompletedOn = new promClient.Gauge({
+  name: 'pgboss_last_job_completed_timestamp_seconds',
+  help: 'Last job completed timestamp',
+  labelNames: ['name'] as const
+});
+
+export const lastProcessedBlockNumber = new promClient.Gauge({
+  name: 'last_processed_block_number',
+  help: 'Last processed block number'
 });
 
 export const lastBlockProcessDuration = new promClient.Gauge({
-  name: 'last_block_process_duration_ms',
-  help: 'Last block process duration (ms)'
+  name: 'last_block_process_duration_seconds',
+  help: 'Last block process duration (seconds)'
 });
 
 export const lastBlockNumEvents = new promClient.Gauge({
-  name: 'last_block_num_events',
+  name: 'last_block_num_events_total',
   help: 'Number of events in the last block'
+});
+
+export const blockProgressCount = new promClient.Gauge({
+  name: 'block_progress_total',
+  help: 'Total entries in block_progress table'
+});
+
+export const eventCount = new promClient.Gauge({
+  name: 'event_total',
+  help: 'Total entries in event table'
 });
 
 // Export metrics on a server
 const app: Application = express();
 
-export async function startMetricsServer (metrics: MetricsConfig): Promise<void> {
-  if (!metrics) {
+export async function startMetricsServer (config: Config, indexer: IndexerInterface): Promise<void> {
+  if (!config.metrics) {
     log('Metrics is disabled. To enable add metrics host and port.');
     return;
   }
 
-  assert(metrics.host, 'Missing config for metrics host');
-  assert(metrics.port, 'Missing config for metrics port');
+  assert(config.metrics.host, 'Missing config for metrics host');
+  assert(config.metrics.port, 'Missing config for metrics port');
+
+  // eslint-disable-next-line no-new
+  new promClient.Gauge({
+    name: 'sync_status_block_number',
+    help: 'Sync status table info',
+    labelNames: ['kind'] as const,
+    async collect () {
+      const syncStatus = await indexer.getSyncStatus();
+
+      if (syncStatus) {
+        this.set({ kind: 'latest_indexed' }, syncStatus.latestIndexedBlockNumber);
+        this.set({ kind: 'latest_canonical' }, syncStatus.latestCanonicalBlockNumber);
+        this.set({ kind: 'chain_head' }, syncStatus.chainHeadBlockNumber);
+      }
+    }
+  });
+
+  await registerDBSizeMetrics(config);
 
   // Add default metrics
   promClient.collectDefaultMetrics();
@@ -45,7 +89,42 @@ export async function startMetricsServer (metrics: MetricsConfig): Promise<void>
     res.send(metrics);
   });
 
-  app.listen(metrics.port, metrics.host, () => {
-    log(`Metrics exposed at http://${metrics.host}:${metrics.port}/metrics`);
+  app.listen(config.metrics.port, config.metrics.host, () => {
+    log(`Metrics exposed at http://${config.metrics.host}:${config.metrics.port}/metrics`);
   });
 }
+
+const registerDBSizeMetrics = async ({ database, jobQueue }: Config): Promise<void> => {
+  const [watcherConn, jobQueueConn] = await Promise.all([
+    createConnection({
+      ...database,
+      name: 'metrics-watcher-connection',
+      synchronize: false
+    }),
+    createConnection({
+      type: 'postgres',
+      url: jobQueue.dbConnectionString,
+      name: 'metrics-job-queue-connection',
+      synchronize: false
+    })
+  ]);
+
+  // eslint-disable-next-line no-new
+  new promClient.Gauge({
+    name: 'database_size_bytes',
+    help: 'Total entries in event table',
+    labelNames: ['type'] as const,
+    async collect () {
+      const [
+        [{ pg_database_size: watcherDBSize }],
+        [{ pg_database_size: jobQueueDBSize }]
+      ] = await Promise.all([
+        watcherConn.query(DB_SIZE_QUERY),
+        jobQueueConn.query(DB_SIZE_QUERY)
+      ]);
+
+      this.set({ type: 'watcher' }, Number(watcherDBSize));
+      this.set({ type: 'job-queue' }, Number(jobQueueDBSize));
+    }
+  });
+};


### PR DESCRIPTION
Part of https://github.com/vulcanize/uniswap-watcher-ts/issues/347 and https://github.com/vulcanize/uniswap-watcher-ts/issues/292

- Add prometheus metrics to monitor:
  - the job-queue
  - total number of blocks and events indexed
  - sync status
  - database sizes
  - total and individual GQL query counts