### PR TITLE
Use eth_calls instead of storage calls in mapping code

### DIFF
--- a/packages/erc20-watcher/src/fill.ts
+++ b/packages/erc20-watcher/src/fill.ts
@@ -22,7 +22,9 @@ const log = debug('vulcanize:server');
 export const main = async (): Promise<any> => {
   const argv = await yargs(hideBin(process.argv)).parserConfiguration({
     'parse-numbers': false
-  }).options({
+  }).env(
+    'FILL'
+  ).options({
     configFile: {
       alias: 'f',
       type: 'string',

--- a/packages/uni-info-watcher/src/fill.ts
+++ b/packages/uni-info-watcher/src/fill.ts
@@ -24,7 +24,9 @@ const log = debug('vulcanize:server');
 export const main = async (): Promise<any> => {
   const argv = await yargs(hideBin(process.argv)).parserConfiguration({
     'parse-numbers': false
-  }).options({
+  }).env(
+    'FILL'
+  ).options({
     configFile: {
       alias: 'f',
       type: 'string',

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -1439,13 +1439,18 @@ export class Indexer implements IndexerInterface {
   }
 
   async _updateFeeVars (position: Position, block: Block, contractAddress: string, tokenId: bigint): Promise<Position> {
-    console.time('time:indexer#_updateFeeVars-storage_call_for_getPosition');
-    const nfpmPosition = await this._uniClient.getPosition(block.hash, tokenId);
-    console.timeEnd('time:indexer#_updateFeeVars-storage_call_for_getPosition');
+    try {
+      console.time('time:indexer#_updateFeeVars-eth_call_for_positions');
+      const { value: positionResult } = await this._uniClient.positions(block.hash, contractAddress, tokenId);
+      console.timeEnd('time:indexer#_updateFeeVars-eth_call_for_positions');
 
-    if (nfpmPosition) {
-      position.feeGrowthInside0LastX128 = BigInt(nfpmPosition.feeGrowthInside0LastX128.toString());
-      position.feeGrowthInside1LastX128 = BigInt(nfpmPosition.feeGrowthInside1LastX128.toString());
+      if (positionResult) {
+        position.feeGrowthInside0LastX128 = BigInt(positionResult.feeGrowthInside0LastX128.toString());
+        position.feeGrowthInside1LastX128 = BigInt(positionResult.feeGrowthInside1LastX128.toString());
+      }
+    } catch (error) {
+      log('nfpm positions eth_call failed');
+      log(error);
     }
 
     return position;

--- a/packages/uni-watcher/src/fill.ts
+++ b/packages/uni-watcher/src/fill.ts
@@ -22,7 +22,9 @@ const log = debug('vulcanize:server');
 export const main = async (): Promise<any> => {
   const argv = await yargs(hideBin(process.argv)).parserConfiguration({
     'parse-numbers': false
-  }).options({
+  }).env(
+    'FILL'
+  ).options({
     configFile: {
       alias: 'f',
       type: 'string',


### PR DESCRIPTION
Part of https://github.com/vulcanize/uniswap-watcher-ts/issues/292

- Using eth_calls due to issue in using getStorageAt calls in ipld-eth-server
- Added option to pass environment variables in fill CLI