### PR TITLE
Add back omitted entities and fields from uniswap subgraph 

### DIFF
--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -57,6 +57,10 @@ import { TickDayData } from './entity/TickDayData';
 import { Contract } from './entity/Contract';
 import { IPLDBlock } from './entity/IPLDBlock';
 import { IpldStatus } from './entity/IpldStatus';
+import { Collect } from './entity/Collect';
+import { Flash } from './entity/Flash';
+import { TickHourData } from './entity/TickHourData';
+import { resolveEntityFieldConflicts } from './utils';
 
 const log = debug('vulcanize:database');
 
@@ -589,6 +593,7 @@ export class Database implements DatabaseInterface {
     }
 
     entities = await this.loadRelations(queryRunner, block, this._relationsMap, entity, entities, selections);
+    entities = entities.map(entity => resolveEntityFieldConflicts(entity));
 
     return entities;
   }
@@ -1361,6 +1366,41 @@ export class Database implements DatabaseInterface {
       token1: {
         entity: Token,
         type: 'one-to-one'
+      },
+      poolHourData: {
+        entity: PoolHourData,
+        type: 'one-to-many',
+        foreignKey: 'pool'
+      },
+      poolDayData: {
+        entity: PoolDayData,
+        type: 'one-to-many',
+        foreignKey: 'pool'
+      },
+      mints: {
+        entity: Mint,
+        type: 'one-to-many',
+        foreignKey: 'pool'
+      },
+      burns: {
+        entity: Burn,
+        type: 'one-to-many',
+        foreignKey: 'pool'
+      },
+      swaps: {
+        entity: Swap,
+        type: 'one-to-many',
+        foreignKey: 'pool'
+      },
+      collects: {
+        entity: Collect,
+        type: 'one-to-many',
+        foreignKey: 'pool'
+      },
+      ticks: {
+        entity: Tick,
+        type: 'one-to-many',
+        foreignKey: 'pool'
       }
     });
 
@@ -1371,6 +1411,14 @@ export class Database implements DatabaseInterface {
       },
       transaction: {
         entity: Transaction,
+        type: 'one-to-one'
+      },
+      token0: {
+        entity: Token,
+        type: 'one-to-one'
+      },
+      token1: {
+        entity: Token,
         type: 'one-to-one'
       }
     });
@@ -1417,6 +1465,11 @@ export class Database implements DatabaseInterface {
       whitelistPools: {
         entity: Pool,
         type: 'many-to-many'
+      },
+      tokenDayData: {
+        entity: TokenDayData,
+        type: 'one-to-many',
+        foreignKey: 'token'
       }
     });
 
@@ -1433,6 +1486,16 @@ export class Database implements DatabaseInterface {
       },
       swaps: {
         entity: Swap,
+        type: 'one-to-many',
+        foreignKey: 'transaction'
+      },
+      flashed: {
+        entity: Flash,
+        type: 'one-to-many',
+        foreignKey: 'transaction'
+      },
+      collects: {
+        entity: Collect,
         type: 'one-to-many',
         foreignKey: 'transaction'
       }
@@ -1472,6 +1535,13 @@ export class Database implements DatabaseInterface {
       }
     });
 
+    this._relationsMap.set(PoolHourData, {
+      pool: {
+        entity: Pool,
+        type: 'one-to-one'
+      }
+    });
+
     this._relationsMap.set(TokenDayData, {
       token: {
         entity: Token,
@@ -1482,6 +1552,65 @@ export class Database implements DatabaseInterface {
     this._relationsMap.set(TokenHourData, {
       token: {
         entity: Token,
+        type: 'one-to-one'
+      }
+    });
+
+    this._relationsMap.set(Collect, {
+      transaction: {
+        entity: Transaction,
+        type: 'one-to-one'
+      },
+      pool: {
+        entity: Pool,
+        type: 'one-to-one'
+      }
+    });
+
+    this._relationsMap.set(Flash, {
+      transaction: {
+        entity: Transaction,
+        type: 'one-to-one'
+      },
+      pool: {
+        entity: Pool,
+        type: 'one-to-one'
+      }
+    });
+
+    this._relationsMap.set(PositionSnapshot, {
+      pool: {
+        entity: Pool,
+        type: 'one-to-one'
+      },
+      position: {
+        entity: Position,
+        type: 'one-to-one'
+      },
+      transaction: {
+        entity: Transaction,
+        type: 'one-to-one'
+      }
+    });
+
+    this._relationsMap.set(TickDayData, {
+      pool: {
+        entity: Pool,
+        type: 'one-to-one'
+      },
+      tick: {
+        entity: Tick,
+        type: 'one-to-one'
+      }
+    });
+
+    this._relationsMap.set(TickHourData, {
+      pool: {
+        entity: Pool,
+        type: 'one-to-one'
+      },
+      tick: {
+        entity: Tick,
         type: 'one-to-one'
       }
     });

--- a/packages/uni-info-watcher/src/entity/Burn.ts
+++ b/packages/uni-info-watcher/src/entity/Burn.ts
@@ -57,4 +57,7 @@ export class Burn {
 
   @Column('numeric', { transformer: bigintTransformer })
   tickUpper!: bigint
+
+  @Column('numeric', { transformer: bigintTransformer })
+  logIndex!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/Collect.ts
+++ b/packages/uni-info-watcher/src/entity/Collect.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Vulcanize, Inc.
+// Copyright 2022 Vulcanize, Inc.
 //
 
 import { Entity, PrimaryColumn, Column, Index } from 'typeorm';
@@ -7,14 +7,10 @@ import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulca
 
 @Entity()
 @Index(['id', 'blockNumber'])
-@Index(['transaction'])
-@Index(['blockHash', 'id', 'token0'])
-@Index(['blockHash', 'id', 'token1'])
-export class Mint {
-  @PrimaryColumn('varchar')
+export class Collect {
+  @PrimaryColumn('varchar', { length: 42 })
   id!: string;
 
-  // https://typeorm.io/#/entities/primary-columns
   @PrimaryColumn('varchar', { length: 66 })
   blockHash!: string
 
@@ -22,31 +18,16 @@ export class Mint {
   blockNumber!: number;
 
   @Column('varchar')
-  transaction!: string;
+  transaction!: string
 
   @Column('numeric', { transformer: bigintTransformer })
-  timestamp!: bigint;
+  timestamp!: bigint
 
   @Column('varchar', { length: 42 })
-  pool!: string;
-
-  @Column('varchar', { length: 42 })
-  token0!: string
-
-  @Column('varchar', { length: 42 })
-  token1!: string
+  pool!: string
 
   @Column('varchar', { length: 42 })
   owner!: string
-
-  @Column('varchar', { length: 42 })
-  sender!: string
-
-  @Column('varchar', { length: 42 })
-  origin!: string
-
-  @Column('numeric', { transformer: bigintTransformer })
-  amount!: bigint
 
   @Column('numeric', { transformer: graphDecimalTransformer })
   amount0!: GraphDecimal
@@ -63,6 +44,6 @@ export class Mint {
   @Column('numeric', { transformer: bigintTransformer })
   tickUpper!: bigint
 
-  @Column('numeric', { transformer: bigintTransformer })
+  @Column('numeric', { nullable: true, transformer: bigintTransformer })
   logIndex!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/Factory.ts
+++ b/packages/uni-info-watcher/src/entity/Factory.ts
@@ -4,6 +4,7 @@
 
 import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulcanize/util';
+import { ADDRESS_ZERO } from '../utils/constants';
 
 @Entity()
 @Index(['id', 'blockNumber'])
@@ -45,5 +46,12 @@ export class Factory {
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   untrackedVolumeUSD!: GraphDecimal
 
-  // TODO: Add remaining fields when they are used.
+  @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
+  totalValueLockedUSDUntracked!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
+  totalValueLockedETHUntracked!: GraphDecimal
+
+  @Column('varchar', { length: 42, default: ADDRESS_ZERO })
+  owner!: string
 }

--- a/packages/uni-info-watcher/src/entity/Flash.ts
+++ b/packages/uni-info-watcher/src/entity/Flash.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Vulcanize, Inc.
+// Copyright 2022 Vulcanize, Inc.
 //
 
 import { Entity, PrimaryColumn, Column, Index } from 'typeorm';
@@ -7,14 +7,10 @@ import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulca
 
 @Entity()
 @Index(['id', 'blockNumber'])
-@Index(['transaction'])
-@Index(['blockHash', 'id', 'token0'])
-@Index(['blockHash', 'id', 'token1'])
-export class Mint {
-  @PrimaryColumn('varchar')
+export class Flash {
+  @PrimaryColumn('varchar', { length: 42 })
   id!: string;
 
-  // https://typeorm.io/#/entities/primary-columns
   @PrimaryColumn('varchar', { length: 66 })
   blockHash!: string
 
@@ -27,26 +23,14 @@ export class Mint {
   @Column('numeric', { transformer: bigintTransformer })
   timestamp!: bigint;
 
-  @Column('varchar', { length: 42 })
-  pool!: string;
-
-  @Column('varchar', { length: 42 })
-  token0!: string
-
-  @Column('varchar', { length: 42 })
-  token1!: string
-
-  @Column('varchar', { length: 42 })
-  owner!: string
+  @Column('varchar')
+  pool!: string
 
   @Column('varchar', { length: 42 })
   sender!: string
 
   @Column('varchar', { length: 42 })
-  origin!: string
-
-  @Column('numeric', { transformer: bigintTransformer })
-  amount!: bigint
+  recipient!: string
 
   @Column('numeric', { transformer: graphDecimalTransformer })
   amount0!: GraphDecimal
@@ -57,11 +41,11 @@ export class Mint {
   @Column('numeric', { transformer: graphDecimalTransformer })
   amountUSD!: GraphDecimal
 
-  @Column('numeric', { transformer: bigintTransformer })
-  tickLower!: bigint
+  @Column('numeric', { transformer: graphDecimalTransformer })
+  amount0Paid!: GraphDecimal
 
-  @Column('numeric', { transformer: bigintTransformer })
-  tickUpper!: bigint
+  @Column('numeric', { transformer: graphDecimalTransformer })
+  amount1Paid!: GraphDecimal
 
   @Column('numeric', { transformer: bigintTransformer })
   logIndex!: bigint

--- a/packages/uni-info-watcher/src/entity/Pool.ts
+++ b/packages/uni-info-watcher/src/entity/Pool.ts
@@ -78,5 +78,27 @@ export class Pool {
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
 
-  // TODO: Add remaining fields when they are used.
+  @Column('numeric', { transformer: bigintTransformer })
+  createdAtTimestamp!: bigint
+
+  @Column('numeric', { transformer: bigintTransformer })
+  createdAtBlockNumber!: bigint
+
+  @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
+  observationIndex!: bigint
+
+  @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
+  collectedFeesToken0!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
+  collectedFeesToken1!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
+  collectedFeesUSD!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
+  totalValueLockedUSDUntracked!: GraphDecimal
+
+  @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
+  liquidityProviderCount!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/Pool.ts
+++ b/packages/uni-info-watcher/src/entity/Pool.ts
@@ -42,12 +42,6 @@ export class Pool {
   @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
   liquidity!: bigint
 
-  @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
-  feeGrowthGlobal0X128!: bigint
-
-  @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
-  feeGrowthGlobal1X128!: bigint
-
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   totalValueLockedUSD!: GraphDecimal
 
@@ -101,4 +95,11 @@ export class Pool {
 
   @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
   liquidityProviderCount!: bigint
+
+  // Skipping fee growth as they are not queried.
+  // @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
+  // feeGrowthGlobal0X128!: bigint
+
+  // @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
+  // feeGrowthGlobal1X128!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/PoolDayData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolDayData.ts
@@ -46,12 +46,6 @@ export class PoolDayData {
   @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
   liquidity!: bigint
 
-  @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
-  feeGrowthGlobal0X128!: bigint
-
-  @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
-  feeGrowthGlobal1X128!: bigint
-
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   token0Price!: GraphDecimal
 
@@ -75,4 +69,11 @@ export class PoolDayData {
 
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
+
+  // Skipping fee growth as they are not queried.
+  // @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
+  // feeGrowthGlobal0X128!: bigint
+
+  // @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
+  // feeGrowthGlobal1X128!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/PoolDayData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolDayData.ts
@@ -75,6 +75,4 @@ export class PoolDayData {
 
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
-
-  // TODO: Add remaining fields when they are used.
 }

--- a/packages/uni-info-watcher/src/entity/PoolHourData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolHourData.ts
@@ -45,12 +45,6 @@ export class PoolHourData {
   @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
   liquidity!: bigint
 
-  @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
-  feeGrowthGlobal0X128!: bigint
-
-  @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
-  feeGrowthGlobal1X128!: bigint
-
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   token0Price!: GraphDecimal
 
@@ -74,4 +68,11 @@ export class PoolHourData {
 
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
+
+  // Skipping fee growth as they are not queried.
+  // @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
+  // feeGrowthGlobal0X128!: bigint
+
+  // @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
+  // feeGrowthGlobal1X128!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/PoolHourData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolHourData.ts
@@ -74,6 +74,4 @@ export class PoolHourData {
 
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
-
-  // TODO: Add remaining fields when they are used.
 }

--- a/packages/uni-info-watcher/src/entity/PositionSnapshot.ts
+++ b/packages/uni-info-watcher/src/entity/PositionSnapshot.ts
@@ -59,6 +59,9 @@ export class PositionSnapshot {
   @Column('varchar')
   position!: string
 
+  @Column('numeric', { transformer: bigintTransformer })
+  _blockNumber!: bigint;
+
   @Column('varchar')
   transaction!: string
 }

--- a/packages/uni-info-watcher/src/entity/Swap.ts
+++ b/packages/uni-info-watcher/src/entity/Swap.ts
@@ -57,4 +57,7 @@ export class Swap {
 
   @Column('numeric', { transformer: bigintTransformer })
   sqrtPriceX96!: bigint
+
+  @Column('numeric', { transformer: bigintTransformer })
+  logIndex!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/Tick.ts
+++ b/packages/uni-info-watcher/src/entity/Tick.ts
@@ -38,4 +38,43 @@ export class Tick {
 
   @Column('numeric', { default: 0, transformer: bigintTransformer })
   liquidityNet!: bigint
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  volumeToken0!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  volumeToken1!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  volumeUSD!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  untrackedVolumeUSD!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  feesUSD!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  collectedFeesToken0!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  collectedFeesToken1!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  collectedFeesUSD!: GraphDecimal
+
+  @Column('numeric', { transformer: bigintTransformer })
+  createdAtTimestamp!: bigint
+
+  @Column('numeric', { transformer: bigintTransformer })
+  createdAtBlockNumber!: bigint
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  liquidityProviderCount!: bigint
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  feeGrowthOutside0X128!: bigint
+
+  @Column('numeric', { default: 0, transformer: bigintTransformer })
+  feeGrowthOutside1X128!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/TickHourData.ts
+++ b/packages/uni-info-watcher/src/entity/TickHourData.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Vulcanize, Inc.
+// Copyright 2022 Vulcanize, Inc.
 //
 
 import { Entity, PrimaryColumn, Column, Index } from 'typeorm';
@@ -7,7 +7,7 @@ import { bigintTransformer, GraphDecimal, graphDecimalTransformer } from '@vulca
 
 @Entity()
 @Index(['id', 'blockNumber'])
-export class TickDayData {
+export class TickHourData {
   @PrimaryColumn('varchar')
   id!: string;
 
@@ -17,9 +17,6 @@ export class TickDayData {
 
   @Column('integer')
   blockNumber!: number;
-
-  @Column('integer')
-  date!: number
 
   @Column('varchar', { length: 42 })
   pool!: string;
@@ -33,6 +30,9 @@ export class TickDayData {
   @Column('numeric', { transformer: bigintTransformer })
   liquidityNet!: bigint;
 
+  @Column('integer')
+  periodStartUnix!: number
+
   @Column('numeric', { transformer: graphDecimalTransformer })
   volumeToken0!: GraphDecimal
 
@@ -44,10 +44,4 @@ export class TickDayData {
 
   @Column('numeric', { transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
-
-  @Column('numeric', { default: 0, transformer: bigintTransformer })
-  feeGrowthOutside0X128!: bigint
-
-  @Column('numeric', { default: 0, transformer: bigintTransformer })
-  feeGrowthOutside1X128!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/Token.ts
+++ b/packages/uni-info-watcher/src/entity/Token.ts
@@ -57,5 +57,9 @@ export class Token {
   @Column('varchar', { length: 42, array: true, default: [] })
   whitelistPools!: string[];
 
-  // TODO: Add remaining fields when they are used.
+  @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
+  poolCount!: bigint
+
+  @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
+  totalValueLockedUSDUntracked!: GraphDecimal
 }

--- a/packages/uni-info-watcher/src/entity/Transaction.ts
+++ b/packages/uni-info-watcher/src/entity/Transaction.ts
@@ -20,4 +20,13 @@ export class Transaction {
 
   @Column('numeric', { transformer: bigintTransformer })
   timestamp!: bigint;
+
+  @Column('numeric', { transformer: bigintTransformer })
+  _blockNumber!: bigint;
+
+  @Column('numeric', { transformer: bigintTransformer })
+  gasUsed!: bigint
+
+  @Column('numeric', { transformer: bigintTransformer })
+  gasPrice!: bigint
 }

--- a/packages/uni-info-watcher/src/entity/UniswapDayData.ts
+++ b/packages/uni-info-watcher/src/entity/UniswapDayData.ts
@@ -35,4 +35,7 @@ export class UniswapDayData {
 
   @Column('numeric', { transformer: graphDecimalTransformer, default: 0 })
   feesUSD!: GraphDecimal
+
+  @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
+  volumeUSDUntracked!: GraphDecimal
 }

--- a/packages/uni-info-watcher/src/events.ts
+++ b/packages/uni-info-watcher/src/events.ts
@@ -60,6 +60,16 @@ export interface SwapEvent {
   tick: string;
 }
 
+export interface FlashEvent {
+  __typename: 'FlashEvent';
+  sender: string;
+  recipient: string;
+  amount0: string;
+  amount1: string;
+  paid0: string;
+  paid1: string;
+}
+
 export interface IncreaseLiquidityEvent {
   __typename: 'IncreaseLiquidityEvent';
   tokenId: string;
@@ -103,6 +113,12 @@ export interface Transaction {
   from: string;
   to: string;
   index: number;
+  value: string;
+  gasLimit: string;
+  gasPrice?: string;
+  input: string;
+  maxPriorityFeePerGas?: string,
+  maxFeePerGas?: string,
 }
 
 export interface ResultEvent {
@@ -110,7 +126,7 @@ export interface ResultEvent {
   tx: Transaction;
   contract: string;
   eventIndex: number;
-  event: PoolCreatedEvent | InitializeEvent | MintEvent | BurnEvent | SwapEvent | IncreaseLiquidityEvent | DecreaseLiquidityEvent | CollectEvent | TransferEvent;
+  event: PoolCreatedEvent | InitializeEvent | MintEvent | BurnEvent | SwapEvent | FlashEvent | IncreaseLiquidityEvent | DecreaseLiquidityEvent | CollectEvent | TransferEvent;
   proof: {
     data: string;
   }

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -1372,21 +1372,22 @@ export class Indexer implements IndexerInterface {
       swap.sqrtPriceX96 = BigInt(swapEvent.sqrtPriceX96);
       swap.logIndex = BigInt(eventIndex);
 
-      // Update fee growth.
-      console.time('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
-      const endTimer = eventProcessingEthCallDuration.startTimer();
-      const [
-        { value: feeGrowthGlobal0X128 },
-        { value: feeGrowthGlobal1X128 }
-      ] = await Promise.all([
-        this._uniClient.feeGrowthGlobal0X128(block.hash, contractAddress),
-        this._uniClient.feeGrowthGlobal1X128(block.hash, contractAddress)
-      ]);
-      endTimer();
-      console.timeEnd('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
+      // Skipping update pool fee growth as they are not queried.
+      // // Update fee growth.
+      // console.time('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
+      // const endTimer = eventProcessingEthCallDuration.startTimer();
+      // const [
+      //   { value: feeGrowthGlobal0X128 },
+      //   { value: feeGrowthGlobal1X128 }
+      // ] = await Promise.all([
+      //   this._uniClient.feeGrowthGlobal0X128(block.hash, contractAddress),
+      //   this._uniClient.feeGrowthGlobal1X128(block.hash, contractAddress)
+      // ]);
+      // endTimer();
+      // console.timeEnd('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
 
-      pool.feeGrowthGlobal0X128 = BigInt(feeGrowthGlobal0X128);
-      pool.feeGrowthGlobal1X128 = BigInt(feeGrowthGlobal1X128);
+      // pool.feeGrowthGlobal0X128 = BigInt(feeGrowthGlobal0X128);
+      // pool.feeGrowthGlobal1X128 = BigInt(feeGrowthGlobal1X128);
 
       // Interval data.
       const uniswapDayData = await updateUniswapDayData(this._db, dbTx, { block, contractAddress }, this._isDemo);
@@ -1521,20 +1522,22 @@ export class Indexer implements IndexerInterface {
       const pool = await this._db.getPool(dbTx, { id: poolAddress, blockHash: block.hash });
       assert(pool);
 
-      console.time('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
-      const endTimer = eventProcessingEthCallDuration.startTimer();
-      const [
-        { value: feeGrowthGlobal0X128 },
-        { value: feeGrowthGlobal1X128 }
-      ] = await Promise.all([
-        this._uniClient.feeGrowthGlobal0X128(block.hash, contractAddress),
-        this._uniClient.feeGrowthGlobal1X128(block.hash, contractAddress)
-      ]);
-      endTimer();
-      console.timeEnd('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
+      // Skipping update pool fee growth as they are not queried.
+      // console.time('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
+      // const endTimer = eventProcessingEthCallDuration.startTimer();
+      // const [
+      //   { value: feeGrowthGlobal0X128 },
+      //   { value: feeGrowthGlobal1X128 }
+      // ] = await Promise.all([
+      //   this._uniClient.feeGrowthGlobal0X128(block.hash, contractAddress),
+      //   this._uniClient.feeGrowthGlobal1X128(block.hash, contractAddress)
+      // ]);
+      // endTimer();
+      // console.timeEnd('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
 
-      pool.feeGrowthGlobal0X128 = BigInt(feeGrowthGlobal0X128);
-      pool.feeGrowthGlobal1X128 = BigInt(feeGrowthGlobal1X128);
+      // pool.feeGrowthGlobal0X128 = BigInt(feeGrowthGlobal0X128);
+      // pool.feeGrowthGlobal1X128 = BigInt(feeGrowthGlobal1X128);
+
       await this._db.savePool(dbTx, pool, block);
     } catch (error) {
       await dbTx.rollbackTransaction();

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -14,20 +14,20 @@ import * as codec from '@ipld/dag-cbor';
 import { Client as UniClient } from '@vulcanize/uni-watcher';
 import { Client as ERC20Client } from '@vulcanize/erc20-watcher';
 import { GraphDecimal, JobQueue } from '@vulcanize/util';
-import { ServerConfig, IPFSClient, IpldStatus as IpldStatusInterface, ValueResult, Indexer as BaseIndexer, IndexerInterface, QueryOptions, OrderDirection, BlockHeight, Where, ResultIPLDBlock, eventProcessingEthCallDuration } from '@cerc-io/util';
+import { ServerConfig, IPFSClient, IpldStatus as IpldStatusInterface, ValueResult, Indexer as BaseIndexer, IndexerInterface, QueryOptions, OrderDirection, BlockHeight, Where, ResultIPLDBlock, eventProcessingEthCallDuration, getFullTransaction, getFullBlock } from '@cerc-io/util';
 import { EthClient } from '@cerc-io/ipld-eth-client';
 import { StorageLayout, MappingKey } from '@cerc-io/solidity-mapper';
 
 import { findEthPerToken, getEthPriceInUSD, getTrackedAmountUSD, sqrtPriceX96ToTokenPrices, WHITELIST_TOKENS } from './utils/pricing';
 import { updatePoolDayData, updatePoolHourData, updateTickDayData, updateTokenDayData, updateTokenHourData, updateUniswapDayData } from './utils/interval-updates';
 import { Token } from './entity/Token';
-import { convertTokenToDecimal, loadFactory, loadTransaction, safeDiv } from './utils';
+import { convertTokenToDecimal, loadFactory, loadTransaction, safeDiv, Block } from './utils';
 import { createTick, feeTierToTickSpacing } from './utils/tick';
-import { FACTORY_ADDRESS, WATCHED_CONTRACTS } from './utils/constants';
+import { ADDRESS_ZERO, FACTORY_ADDRESS, WATCHED_CONTRACTS } from './utils/constants';
 import { Position } from './entity/Position';
 import { Database, DEFAULT_LIMIT } from './database';
 import { Event } from './entity/Event';
-import { ResultEvent, Block, Transaction, PoolCreatedEvent, InitializeEvent, MintEvent, BurnEvent, SwapEvent, IncreaseLiquidityEvent, DecreaseLiquidityEvent, CollectEvent, TransferEvent } from './events';
+import { ResultEvent, Transaction, PoolCreatedEvent, InitializeEvent, MintEvent, BurnEvent, SwapEvent, IncreaseLiquidityEvent, DecreaseLiquidityEvent, CollectEvent, TransferEvent, FlashEvent } from './events';
 import { Factory } from './entity/Factory';
 import { Bundle } from './entity/Bundle';
 import { Pool } from './entity/Pool';
@@ -54,11 +54,13 @@ export class Indexer implements IndexerInterface {
   _uniClient: UniClient
   _erc20Client: ERC20Client
   _ethClient: EthClient
+  _ethProvider: providers.BaseProvider
   _baseIndexer: BaseIndexer
   _serverConfig: ServerConfig
   _isDemo: boolean
   _storageLayoutMap: Map<string, StorageLayout> = new Map()
   _subgraphStateMap: Map<string, any> = new Map()
+  _fullBlock?: Block
 
   constructor (serverConfig: ServerConfig, db: Database, uniClient: UniClient, erc20Client: ERC20Client, ethClient: EthClient, ethProvider: providers.BaseProvider, jobQueue: JobQueue) {
     assert(db);
@@ -69,9 +71,10 @@ export class Indexer implements IndexerInterface {
     this._uniClient = uniClient;
     this._erc20Client = erc20Client;
     this._ethClient = ethClient;
+    this._ethProvider = ethProvider;
     this._serverConfig = serverConfig;
     const ipfsClient = new IPFSClient(this._serverConfig.ipfsApiAddr);
-    this._baseIndexer = new BaseIndexer(this._serverConfig, this._db, this._ethClient, ethProvider, jobQueue, ipfsClient);
+    this._baseIndexer = new BaseIndexer(this._serverConfig, this._db, this._ethClient, this._ethProvider, jobQueue, ipfsClient);
     this._isDemo = this._serverConfig.mode === 'demo';
   }
 
@@ -222,53 +225,71 @@ export class Indexer implements IndexerInterface {
     const resultEvent = this.getResultEvent(dbEvent);
 
     // TODO: Process proof (proof.data) in event.
-    const { contract, tx, block, event } = resultEvent;
+    const { contract, tx, block, event, eventIndex } = resultEvent;
     const { __typename: eventName } = event;
+
+    if (!this._fullBlock || (this._fullBlock.hash !== block.hash)) {
+      const { blockHash, blockNumber, timestamp, ...blockData } = await getFullBlock(this._ethClient, this._ethProvider, block.hash);
+
+      this._fullBlock = {
+        hash: blockHash,
+        number: blockNumber,
+        timestamp: Number(timestamp),
+        ...blockData
+      };
+
+      assert(this._fullBlock);
+    }
 
     switch (eventName) {
       case 'PoolCreatedEvent':
         log('Factory PoolCreated event', contract);
-        await this._handlePoolCreated(block, contract, tx, event as PoolCreatedEvent);
+        await this._handlePoolCreated(this._fullBlock, contract, tx, event as PoolCreatedEvent);
         break;
 
       case 'InitializeEvent':
         log('Pool Initialize event', contract);
-        await this._handleInitialize(block, contract, tx, event as InitializeEvent);
+        await this._handleInitialize(this._fullBlock, contract, tx, event as InitializeEvent);
         break;
 
       case 'MintEvent':
         log('Pool Mint event', contract);
-        await this._handleMint(block, contract, tx, event as MintEvent);
+        await this._handleMint(this._fullBlock, contract, tx, event as MintEvent, eventIndex);
         break;
 
       case 'BurnEvent':
         log('Pool Burn event', contract);
-        await this._handleBurn(block, contract, tx, event as BurnEvent);
+        await this._handleBurn(this._fullBlock, contract, tx, event as BurnEvent, eventIndex);
         break;
 
       case 'SwapEvent':
         log('Pool Swap event', contract);
-        await this._handleSwap(block, contract, tx, event as SwapEvent);
+        await this._handleSwap(this._fullBlock, contract, tx, event as SwapEvent, eventIndex);
+        break;
+
+      case 'FlashEvent':
+        log('Pool Flash event', contract);
+        await this._handleFlash(this._fullBlock, contract, tx, event as FlashEvent);
         break;
 
       case 'IncreaseLiquidityEvent':
         log('NFPM IncreaseLiquidity event', contract);
-        await this._handleIncreaseLiquidity(block, contract, tx, event as IncreaseLiquidityEvent);
+        await this._handleIncreaseLiquidity(this._fullBlock, contract, tx, event as IncreaseLiquidityEvent);
         break;
 
       case 'DecreaseLiquidityEvent':
         log('NFPM DecreaseLiquidity event', contract);
-        await this._handleDecreaseLiquidity(block, contract, tx, event as DecreaseLiquidityEvent);
+        await this._handleDecreaseLiquidity(this._fullBlock, contract, tx, event as DecreaseLiquidityEvent);
         break;
 
       case 'CollectEvent':
         log('NFPM Collect event', contract);
-        await this._handleCollect(block, contract, tx, event as CollectEvent);
+        await this._handleCollect(this._fullBlock, contract, tx, event as CollectEvent);
         break;
 
       case 'TransferEvent':
         log('NFPM Transfer event', contract);
-        await this._handleTransfer(block, contract, tx, event as TransferEvent);
+        await this._handleTransfer(this._fullBlock, contract, tx, event as TransferEvent);
         break;
 
       default:
@@ -677,6 +698,7 @@ export class Indexer implements IndexerInterface {
     console.timeEnd('time:indexer#_fetchEvents-uni-get-events');
 
     const dbEvents: Array<DeepPartial<Event>> = [];
+    const transactionsMap = new Map();
 
     for (let i = 0; i < events.length; i++) {
       const {
@@ -687,8 +709,21 @@ export class Indexer implements IndexerInterface {
         proof
       } = events[i];
 
+      // Get full transaction for extra params like gasUsed and gasPrice.
+      let transaction = transactionsMap.get(tx.hash);
+
+      if (!transaction) {
+        transaction = await getFullTransaction(this._ethClient, tx.hash);
+        assert(transaction);
+        transactionsMap.set(tx.hash, transaction);
+      }
+
       const { __typename: eventName, ...eventInfo } = event;
-      const extraInfo = { tx, eventIndex };
+
+      const extraInfo = {
+        tx: transaction,
+        eventIndex
+      };
 
       dbEvents.push({
         index: i,
@@ -722,7 +757,7 @@ export class Indexer implements IndexerInterface {
       this._db.getTokenNoTx({ blockHash: block.hash, id: token1Address })
     ]);
 
-    // Create Tokens if not present.
+    // Fetch info if null.
     if (!token0) {
       token0 = await this._initToken(block, token0Address);
     }
@@ -771,9 +806,8 @@ export class Indexer implements IndexerInterface {
       pool.token0 = token0.id;
       pool.token1 = token1.id;
       pool.feeTier = BigInt(fee);
-
-      // Skipping adding createdAtTimestamp field as it is not queried in frontend subgraph.
-
+      pool.createdAtTimestamp = BigInt(block.timestamp);
+      pool.createdAtBlockNumber = BigInt(block.number);
       pool = await this._db.savePool(dbTx, pool, block);
 
       // Update white listed pools.
@@ -885,7 +919,7 @@ export class Indexer implements IndexerInterface {
     }
   }
 
-  async _handleMint (block: Block, contractAddress: string, tx: Transaction, mintEvent: MintEvent): Promise<void> {
+  async _handleMint (block: Block, contractAddress: string, tx: Transaction, mintEvent: MintEvent, eventIndex: number): Promise<void> {
     const dbTx = await this._db.createTransactionRunner();
 
     try {
@@ -973,6 +1007,7 @@ export class Indexer implements IndexerInterface {
       mint.amountUSD = amountUSD;
       mint.tickLower = BigInt(mintEvent.tickLower);
       mint.tickUpper = BigInt(mintEvent.tickUpper);
+      mint.logIndex = BigInt(eventIndex);
 
       // Tick entities.
       const lowerTickIdx = mintEvent.tickLower;
@@ -1034,8 +1069,8 @@ export class Indexer implements IndexerInterface {
       ]);
 
       // Update inner tick vars and save the ticks.
-      await this._updateTickFeeVarsAndSave(dbTx, lowerTick, block);
-      await this._updateTickFeeVarsAndSave(dbTx, upperTick, block);
+      await this._updateTickFeeVarsAndSave(dbTx, lowerTick, block, contractAddress);
+      await this._updateTickFeeVarsAndSave(dbTx, upperTick, block, contractAddress);
 
       await dbTx.commitTransaction();
     } catch (error) {
@@ -1046,7 +1081,7 @@ export class Indexer implements IndexerInterface {
     }
   }
 
-  async _handleBurn (block: Block, contractAddress: string, tx: Transaction, burnEvent: BurnEvent): Promise<void> {
+  async _handleBurn (block: Block, contractAddress: string, tx: Transaction, burnEvent: BurnEvent, eventIndex: number): Promise<void> {
     const dbTx = await this._db.createTransactionRunner();
 
     try {
@@ -1135,6 +1170,7 @@ export class Indexer implements IndexerInterface {
       burn.amountUSD = amountUSD;
       burn.tickLower = BigInt(burnEvent.tickLower);
       burn.tickUpper = BigInt(burnEvent.tickUpper);
+      burn.logIndex = BigInt(eventIndex);
 
       // Tick entities.
       const lowerTickId = poolAddress + '#' + (burnEvent.tickLower).toString();
@@ -1155,8 +1191,8 @@ export class Indexer implements IndexerInterface {
       await updateTokenHourData(this._db, dbTx, token1, { block });
       await updatePoolDayData(this._db, dbTx, { block, contractAddress });
       await updatePoolHourData(this._db, dbTx, { block, contractAddress });
-      await this._updateTickFeeVarsAndSave(dbTx, lowerTick, block);
-      await this._updateTickFeeVarsAndSave(dbTx, upperTick, block);
+      await this._updateTickFeeVarsAndSave(dbTx, lowerTick, block, contractAddress);
+      await this._updateTickFeeVarsAndSave(dbTx, upperTick, block, contractAddress);
 
       [token0, token1] = await Promise.all([
         this._db.saveToken(dbTx, token0, block),
@@ -1167,8 +1203,6 @@ export class Indexer implements IndexerInterface {
       pool.token1 = token1.id;
       pool = await this._db.savePool(dbTx, pool, block);
       await this._db.saveFactory(dbTx, factory, block);
-
-      // Skipping update Tick fee and Tick day data as they are not queried.
 
       lowerTick.pool = pool.id;
       upperTick.pool = pool.id;
@@ -1190,7 +1224,7 @@ export class Indexer implements IndexerInterface {
     }
   }
 
-  async _handleSwap (block: Block, contractAddress: string, tx: Transaction, swapEvent: SwapEvent): Promise<void> {
+  async _handleSwap (block: Block, contractAddress: string, tx: Transaction, swapEvent: SwapEvent, eventIndex: number): Promise<void> {
     const dbTx = await this._db.createTransactionRunner();
 
     try {
@@ -1336,8 +1370,23 @@ export class Indexer implements IndexerInterface {
       swap.amountUSD = amountTotalUSDTracked;
       swap.tick = BigInt(swapEvent.tick);
       swap.sqrtPriceX96 = BigInt(swapEvent.sqrtPriceX96);
+      swap.logIndex = BigInt(eventIndex);
 
-      // Skipping update pool fee growth as they are not queried.
+      // Update fee growth.
+      console.time('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
+      const endTimer = eventProcessingEthCallDuration.startTimer();
+      const [
+        { value: feeGrowthGlobal0X128 },
+        { value: feeGrowthGlobal1X128 }
+      ] = await Promise.all([
+        this._uniClient.feeGrowthGlobal0X128(block.hash, contractAddress),
+        this._uniClient.feeGrowthGlobal1X128(block.hash, contractAddress)
+      ]);
+      endTimer();
+      console.timeEnd('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
+
+      pool.feeGrowthGlobal0X128 = BigInt(feeGrowthGlobal0X128);
+      pool.feeGrowthGlobal1X128 = BigInt(feeGrowthGlobal1X128);
 
       // Interval data.
       const uniswapDayData = await updateUniswapDayData(this._db, dbTx, { block, contractAddress }, this._isDemo);
@@ -1455,6 +1504,38 @@ export class Indexer implements IndexerInterface {
       }
 
       await dbTx.commitTransaction();
+    } catch (error) {
+      await dbTx.rollbackTransaction();
+      throw error;
+    } finally {
+      await dbTx.release();
+    }
+  }
+
+  async _handleFlash (block: Block, contractAddress: string, tx: Transaction, burnEvent: FlashEvent): Promise<void> {
+    const dbTx = await this._db.createTransactionRunner();
+
+    try {
+      // Get the contract address in lowercase as pool address.
+      const poolAddress = utils.hexlify(contractAddress);
+      const pool = await this._db.getPool(dbTx, { id: poolAddress, blockHash: block.hash });
+      assert(pool);
+
+      console.time('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
+      const endTimer = eventProcessingEthCallDuration.startTimer();
+      const [
+        { value: feeGrowthGlobal0X128 },
+        { value: feeGrowthGlobal1X128 }
+      ] = await Promise.all([
+        this._uniClient.feeGrowthGlobal0X128(block.hash, contractAddress),
+        this._uniClient.feeGrowthGlobal1X128(block.hash, contractAddress)
+      ]);
+      endTimer();
+      console.timeEnd('time:indexer#_getPosition-eth_call_for_feeGrowthGlobal');
+
+      pool.feeGrowthGlobal0X128 = BigInt(feeGrowthGlobal0X128);
+      pool.feeGrowthGlobal1X128 = BigInt(feeGrowthGlobal1X128);
+      await this._db.savePool(dbTx, pool, block);
     } catch (error) {
       await dbTx.rollbackTransaction();
       throw error;
@@ -1614,8 +1695,20 @@ export class Indexer implements IndexerInterface {
     }
   }
 
-  async _updateTickFeeVarsAndSave (dbTx: QueryRunner, tick: Tick, block: Block): Promise<void> {
-    // Skipping update feeGrowthOutside0X128 and feeGrowthOutside1X128 data as they are not queried.
+  async _updateTickFeeVarsAndSave (dbTx: QueryRunner, tick: Tick, block: Block, contractAddress: string): Promise<void> {
+    const poolAddress = contractAddress;
+
+    // Not all ticks are initialized so obtaining null is expected behavior.
+    console.time('time:indexer#_getPosition-eth_call_for_ticks');
+    const endTimer = eventProcessingEthCallDuration.startTimer();
+    const { value: tickResult } = await this._uniClient.ticks(block.hash, poolAddress, Number(tick.tickIdx));
+    endTimer();
+    console.timeEnd('time:indexer#_getPosition-eth_call_for_ticks');
+
+    tick.feeGrowthOutside0X128 = tickResult.feeGrowthOutside0X128;
+    tick.feeGrowthOutside1X128 = tickResult.feeGrowthOutside1X128;
+
+    await this._db.saveTick(dbTx, tick, block);
 
     await updateTickDayData(this._db, dbTx, tick, { block });
   }
@@ -1634,7 +1727,7 @@ export class Indexer implements IndexerInterface {
     );
 
     if (tick) {
-      await this._updateTickFeeVarsAndSave(dbTx, tick, block);
+      await this._updateTickFeeVarsAndSave(dbTx, tick, block, contractAddress);
     }
   }
 
@@ -1673,6 +1766,8 @@ export class Indexer implements IndexerInterface {
 
         position = new Position();
         position.id = tokenId.toString();
+        // The owner gets correctly updated in the Transfer handler
+        position.owner = ADDRESS_ZERO;
         position.pool = poolAddress;
         position.token0 = utils.hexlify(positionResult.token0);
         position.token1 = utils.hexlify(positionResult.token1);
@@ -1735,10 +1830,10 @@ export class Indexer implements IndexerInterface {
   async _savePositionSnapshot (dbTx: QueryRunner, position: Position, block: Block, tx: Transaction): Promise<void> {
     const positionSnapshot = new PositionSnapshot();
     positionSnapshot.id = position.id.concat('#').concat(block.number.toString());
-    positionSnapshot.blockNumber = block.number;
     positionSnapshot.owner = position.owner;
     positionSnapshot.pool = position.pool;
     positionSnapshot.position = position.id;
+    positionSnapshot._blockNumber = BigInt(block.number);
     positionSnapshot.timestamp = BigInt(block.timestamp);
     positionSnapshot.liquidity = position.liquidity;
     positionSnapshot.depositedToken0 = position.depositedToken0;

--- a/packages/uni-info-watcher/src/resolvers.ts
+++ b/packages/uni-info-watcher/src/resolvers.ts
@@ -24,8 +24,14 @@ import { TokenDayData } from './entity/TokenDayData';
 import { TokenHourData } from './entity/TokenHourData';
 import { UniswapDayData } from './entity/UniswapDayData';
 import { Position } from './entity/Position';
-import { EventWatcher } from './events';
 import { Transaction } from './entity/Transaction';
+import { PositionSnapshot } from './entity/PositionSnapshot';
+import { TickDayData } from './entity/TickDayData';
+import { TickHourData } from './entity/TickHourData';
+import { Flash } from './entity/Flash';
+import { Collect } from './entity/Collect';
+import { PoolHourData } from './entity/PoolHourData';
+import { EventWatcher } from './events';
 import { FACTORY_ADDRESS, BUNDLE_ID } from './utils/constants';
 
 const log = debug('vulcanize:resolver');
@@ -176,6 +182,26 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
           block,
           where,
           { limit: first, skip, orderBy, orderDirection },
+          info.fieldNodes[0].selectionSet.selections
+        );
+      },
+
+      poolHourDatas: async (
+        _: any,
+        { block, first }: { block: BlockHeight, first: number },
+        __: any,
+        info: GraphQLResolveInfo
+      ) => {
+        log('poolHourDatas', first);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('poolHourDatas').inc(1);
+        assert(info.fieldNodes[0].selectionSet);
+
+        return indexer.getEntities(
+          PoolHourData,
+          block,
+          {},
+          { limit: first },
           info.fieldNodes[0].selectionSet.selections
         );
       },
@@ -351,6 +377,106 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
           Position,
           block,
           where,
+          { limit: first },
+          info.fieldNodes[0].selectionSet.selections
+        );
+      },
+
+      positionSnapshots: async (
+        _: any,
+        { block, first }: { block: BlockHeight, first: number },
+        __: any,
+        info: GraphQLResolveInfo
+      ) => {
+        log('positionSnapshots', first);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('positionSnapshots').inc(1);
+        assert(info.fieldNodes[0].selectionSet);
+
+        return indexer.getEntities(
+          PositionSnapshot,
+          block,
+          {},
+          { limit: first },
+          info.fieldNodes[0].selectionSet.selections
+        );
+      },
+
+      tickDayDatas: async (
+        _: any,
+        { block, first }: { block: BlockHeight, first: number },
+        __: any,
+        info: GraphQLResolveInfo
+      ) => {
+        log('tickDayDatas', first);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('tickDayDatas').inc(1);
+        assert(info.fieldNodes[0].selectionSet);
+
+        return indexer.getEntities(
+          TickDayData,
+          block,
+          {},
+          { limit: first },
+          info.fieldNodes[0].selectionSet.selections
+        );
+      },
+
+      tickHourDatas: async (
+        _: any,
+        { block, first }: { block: BlockHeight, first: number },
+        __: any,
+        info: GraphQLResolveInfo
+      ) => {
+        log('tickHourDatas', first);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('tickHourDatas').inc(1);
+        assert(info.fieldNodes[0].selectionSet);
+
+        return indexer.getEntities(
+          TickHourData,
+          block,
+          {},
+          { limit: first },
+          info.fieldNodes[0].selectionSet.selections
+        );
+      },
+
+      flashes: async (
+        _: any,
+        { block, first }: { block: BlockHeight, first: number },
+        __: any,
+        info: GraphQLResolveInfo
+      ) => {
+        log('flashes', first);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('flashes').inc(1);
+        assert(info.fieldNodes[0].selectionSet);
+
+        return indexer.getEntities(
+          Flash,
+          block,
+          {},
+          { limit: first },
+          info.fieldNodes[0].selectionSet.selections
+        );
+      },
+
+      collects: async (
+        _: any,
+        { block, first }: { block: BlockHeight, first: number },
+        __: any,
+        info: GraphQLResolveInfo
+      ) => {
+        log('collects', first);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('collects').inc(1);
+        assert(info.fieldNodes[0].selectionSet);
+
+        return indexer.getEntities(
+          Collect,
+          block,
+          {},
           { limit: first },
           info.fieldNodes[0].selectionSet.selections
         );

--- a/packages/uni-info-watcher/src/schema.ts
+++ b/packages/uni-info-watcher/src/schema.ts
@@ -44,8 +44,6 @@ type Pool {
   volumeUSD: BigDecimal!
   createdAtTimestamp: BigInt!
   createdAtBlockNumber: BigInt!
-  feeGrowthGlobal0X128: BigInt!
-  feeGrowthGlobal1X128: BigInt!
   observationIndex: BigInt!
   volumeToken0: BigDecimal!
   volumeToken1: BigDecimal!
@@ -57,6 +55,10 @@ type Pool {
   totalValueLockedETH: BigDecimal!
   totalValueLockedUSDUntracked: BigDecimal!
   liquidityProviderCount: BigInt!
+  
+  # Skipping fee growth as they are not queried.
+  # feeGrowthGlobal0X128: BigInt!
+  # feeGrowthGlobal1X128: BigInt!
 }
 
 type PoolDayData {
@@ -71,8 +73,6 @@ type PoolDayData {
   token0Price: BigDecimal!
   token1Price: BigDecimal!
   tick: BigInt
-  feeGrowthGlobal0X128: BigInt!
-  feeGrowthGlobal1X128: BigInt!
   volumeToken0: BigDecimal!
   volumeToken1: BigDecimal!
   txCount: BigInt!
@@ -80,6 +80,10 @@ type PoolDayData {
   high: BigDecimal!
   low: BigDecimal!
   close: BigDecimal!
+
+  # Skipping fee growth as they are not queried.
+  # feeGrowthGlobal0X128: BigInt!
+  # feeGrowthGlobal1X128: BigInt!
 }
 
 type PoolHourData {
@@ -93,8 +97,6 @@ type PoolHourData {
   sqrtPrice: BigInt!
   tick: BigInt
   liquidity: BigInt!
-  feeGrowthGlobal0X128: BigInt!
-  feeGrowthGlobal1X128: BigInt!
   token0Price: BigDecimal!
   token1Price: BigDecimal!
   tvlUSD: BigDecimal!
@@ -103,6 +105,10 @@ type PoolHourData {
   volumeToken1: BigDecimal!
   volumeUSD: BigDecimal!
   feesUSD: BigDecimal!
+
+  # Skipping fee growth as they are not queried.
+  # feeGrowthGlobal0X128: BigInt!
+  # feeGrowthGlobal1X128: BigInt!
 }
 
 type Tick {

--- a/packages/uni-info-watcher/src/schema.ts
+++ b/packages/uni-info-watcher/src/schema.ts
@@ -82,6 +82,29 @@ type PoolDayData {
   close: BigDecimal!
 }
 
+type PoolHourData {
+  id: ID!
+  periodStartUnix: Int!
+  pool: Pool!
+  high: BigDecimal!
+  low: BigDecimal!
+  open: BigDecimal!
+  close: BigDecimal!
+  sqrtPrice: BigInt!
+  tick: BigInt
+  liquidity: BigInt!
+  feeGrowthGlobal0X128: BigInt!
+  feeGrowthGlobal1X128: BigInt!
+  token0Price: BigDecimal!
+  token1Price: BigDecimal!
+  tvlUSD: BigDecimal!
+  txCount: BigInt!
+  volumeToken0: BigDecimal!
+  volumeToken1: BigDecimal!
+  volumeUSD: BigDecimal!
+  feesUSD: BigDecimal!
+}
+
 type Tick {
   id: ID!
   liquidityGross: BigInt!
@@ -89,6 +112,49 @@ type Tick {
   price0: BigDecimal!
   price1: BigDecimal!
   tickIdx: BigInt!
+  poolAddress: String
+  pool: Pool!
+  volumeToken0: BigDecimal!
+  volumeToken1: BigDecimal!
+  volumeUSD: BigDecimal!
+  untrackedVolumeUSD: BigDecimal!
+  feesUSD: BigDecimal!
+  collectedFeesToken0: BigDecimal!
+  collectedFeesToken1: BigDecimal!
+  collectedFeesUSD: BigDecimal!
+  createdAtTimestamp: BigInt!
+  createdAtBlockNumber: BigInt!
+  liquidityProviderCount: BigInt! # used to detect new exchanges
+  feeGrowthOutside0X128: BigInt!
+  feeGrowthOutside1X128: BigInt!
+}
+
+type TickDayData {
+  id: ID!
+  date: Int!
+  pool: Pool!
+  tick: Tick!
+  liquidityGross: BigInt!
+  liquidityNet: BigInt!
+  volumeToken0: BigDecimal!
+  volumeToken1: BigDecimal!
+  volumeUSD: BigDecimal!
+  feesUSD: BigDecimal!
+  feeGrowthOutside0X128: BigInt!
+  feeGrowthOutside1X128: BigInt!
+}
+
+type TickHourData {
+  id: ID!  
+  pool: Pool!
+  tick: Tick!
+  liquidityGross: BigInt!
+  liquidityNet: BigInt!
+  periodStartUnix: Int!
+  volumeToken0: BigDecimal!
+  volumeToken1: BigDecimal!
+  volumeUSD: BigDecimal!
+  feesUSD: BigDecimal!
 }
 
 type Mint {
@@ -107,6 +173,7 @@ type Mint {
   amount: BigInt!
   tickLower: BigInt!
   tickUpper: BigInt!
+  logIndex: BigInt
 }
 
 type Swap {
@@ -124,6 +191,7 @@ type Swap {
   recipient: Bytes!
   sqrtPriceX96: BigInt!
   tick: BigInt!
+  logIndex: BigInt
 }
 
 type Burn {
@@ -136,6 +204,41 @@ type Burn {
   pool: Pool!
   timestamp: BigInt!
   transaction: Transaction!
+  token0: Token!
+  token1: Token!
+  amount: BigInt!
+  tickLower: BigInt!
+  tickUpper: BigInt!
+  logIndex: BigInt
+}
+
+type Collect {
+  id: ID!
+  transaction: Transaction!
+  timestamp: BigInt!
+  pool: Pool!
+  owner: Bytes!
+  amount0: BigDecimal!
+  amount1: BigDecimal!
+  amountUSD: BigDecimal!
+  tickLower: BigInt!
+  tickUpper: BigInt!
+  logIndex: BigInt
+}
+
+type Flash {
+  id: ID!
+  transaction: Transaction!
+  timestamp: BigInt!
+  pool: Pool!
+  sender: Bytes!
+  recipient: Bytes!
+  amount0: BigDecimal!
+  amount1: BigDecimal!
+  amountUSD: BigDecimal!
+  amount0Paid: BigDecimal!
+  amount1Paid: BigDecimal!
+  logIndex: BigInt!
 }
 
 type UniswapDayData {
@@ -171,6 +274,9 @@ type Transaction {
   mints(skip: Int = 0, first: Int = 100, orderBy: Mint_orderBy, orderDirection: OrderDirection, where: Mint_filter): [Mint]!
   swaps(skip: Int = 0, first: Int = 100, orderBy: Swap_orderBy, orderDirection: OrderDirection, where: Swap_filter): [Swap]!
   timestamp: BigInt!
+  blockNumber: BigInt!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
 }
 
 type Token {
@@ -188,6 +294,8 @@ type Token {
   whitelistPools: [Pool]
   totalSupply: BigInt!
   untrackedVolumeUSD: BigDecimal!
+  poolCount: BigInt!
+  totalValueLockedUSDUntracked: BigDecimal!
 }
 
 type TokenDayData {
@@ -247,6 +355,25 @@ type Position {
   feeGrowthInside1LastX128: BigInt!
   withdrawnToken0: BigDecimal!
   withdrawnToken1: BigDecimal!
+}
+
+type PositionSnapshot {
+  id: ID!
+  timestamp: BigInt!
+  feeGrowthInside0LastX128: BigInt!
+  feeGrowthInside1LastX128: BigInt!
+  liquidity: BigInt!
+  depositedToken0: BigDecimal!
+  depositedToken1: BigDecimal!
+  owner: Bytes!
+  withdrawnToken0: BigDecimal!
+  withdrawnToken1: BigDecimal!
+  collectedFeesToken0: BigDecimal!
+  collectedFeesToken1: BigDecimal!
+  pool: Pool!
+  position: Position!
+  blockNumber: BigInt!
+  transaction: Transaction!
 }
 
 type Block {
@@ -504,6 +631,12 @@ type Query {
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [PoolDayData!]!
 
+  poolHourDatas(
+    first: Int = 100
+    block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PoolHourData!]!
+
   pools(
     first: Int = 100
     orderBy: Pool_orderBy
@@ -611,6 +744,36 @@ type Query {
     block: Block_height
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Position!]!
+
+  positionSnapshots(
+    first: Int = 100
+    block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [PositionSnapshot!]!
+
+  tickDayDatas(
+    first: Int = 100
+    block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [TickDayData!]!
+
+  tickHourDatas(
+    first: Int = 100
+    block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [TickHourData!]!
+
+  flashes(
+    first: Int = 100
+    block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Flash!]!
+
+  collects(
+    first: Int = 100
+    block: Block_height
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Collect!]!
 
   blocks(
     first: Int = 100

--- a/packages/uni-info-watcher/src/utils/interval-updates.ts
+++ b/packages/uni-info-watcher/src/utils/interval-updates.ts
@@ -86,8 +86,11 @@ export const updatePoolDayData = async (db: Database, dbTx: QueryRunner, event: 
 
   poolDayData.liquidity = pool.liquidity;
   poolDayData.sqrtPrice = pool.sqrtPrice;
-  poolDayData.feeGrowthGlobal0X128 = pool.feeGrowthGlobal0X128;
-  poolDayData.feeGrowthGlobal1X128 = pool.feeGrowthGlobal1X128;
+
+  // Skipping fee growth as they are not queried.
+  // poolDayData.feeGrowthGlobal0X128 = pool.feeGrowthGlobal0X128;
+  // poolDayData.feeGrowthGlobal1X128 = pool.feeGrowthGlobal1X128;
+
   poolDayData.token0Price = pool.token0Price;
   poolDayData.token1Price = pool.token1Price;
   poolDayData.tick = pool.tick;
@@ -135,8 +138,11 @@ export const updatePoolHourData = async (db: Database, dbTx: QueryRunner, event:
   poolHourData.sqrtPrice = pool.sqrtPrice;
   poolHourData.token0Price = pool.token0Price;
   poolHourData.token1Price = pool.token1Price;
-  poolHourData.feeGrowthGlobal0X128 = pool.feeGrowthGlobal0X128;
-  poolHourData.feeGrowthGlobal1X128 = pool.feeGrowthGlobal1X128;
+
+  // Skipping fee growth as they are not queried.
+  // poolHourData.feeGrowthGlobal0X128 = pool.feeGrowthGlobal0X128;
+  // poolHourData.feeGrowthGlobal1X128 = pool.feeGrowthGlobal1X128;
+
   poolHourData.close = pool.token0Price;
   poolHourData.tick = pool.tick;
   poolHourData.tvlUSD = pool.totalValueLockedUSD;

--- a/packages/uni-info-watcher/src/utils/state.ts
+++ b/packages/uni-info-watcher/src/utils/state.ts
@@ -3,6 +3,7 @@
 //
 
 import { jsonBigIntStringReplacer } from '@cerc-io/util';
+import { resolveEntityFieldConflicts } from './index';
 
 export const prepareEntityState = (updatedEntity: any, entityName: string, relationsMap: Map<any, { [key: string]: any }>): any => {
   // Resolve any field name conflicts in the dbData for auto-diff.
@@ -49,26 +50,4 @@ export const prepareEntityState = (updatedEntity: any, entityName: string, relat
   };
 
   return diffData;
-};
-
-const resolveEntityFieldConflicts = (entity: any): any => {
-  if (entity) {
-    // Remove fields blockHash and blockNumber from the entity.
-    delete entity.blockHash;
-    delete entity.blockNumber;
-
-    // Rename _blockHash -> blockHash.
-    if ('_blockHash' in entity) {
-      entity.blockHash = entity._blockHash;
-      delete entity._blockHash;
-    }
-
-    // Rename _blockNumber -> blockNumber.
-    if ('_blockNumber' in entity) {
-      entity.blockNumber = entity._blockNumber;
-      delete entity._blockNumber;
-    }
-  }
-
-  return entity;
 };

--- a/packages/uni-info-watcher/src/utils/tick.ts
+++ b/packages/uni-info-watcher/src/utils/tick.ts
@@ -18,6 +18,8 @@ export const createTick = async (db: Database, dbTx: QueryRunner, tickId: string
   tick.tickIdx = tickIdx;
   tick.pool = pool.id;
   tick.poolAddress = pool.id;
+  tick.createdAtTimestamp = BigInt(block.timestamp);
+  tick.createdAtBlockNumber = BigInt(block.number);
 
   // 1.0001^tick is token1/token0.
   const price0 = bigDecimalExponated(new GraphDecimal('1.0001'), tickIdx);

--- a/packages/uni-info-watcher/test/queries/burns.gql
+++ b/packages/uni-info-watcher/test/queries/burns.gql
@@ -13,5 +13,15 @@ query burns($block: Block_height){
     pool{
       id
     }
+    token0 {
+      id
+    }
+    token1 {
+      id
+    }
+    amount
+    tickLower
+    tickUpper
+    logIndex
   }
 }

--- a/packages/uni-info-watcher/test/queries/collects.gql
+++ b/packages/uni-info-watcher/test/queries/collects.gql
@@ -1,0 +1,19 @@
+query collects($block: Block_height){
+  collects(block: $block){
+    id
+    pool {
+      id
+    }
+    transaction {
+      id
+    }
+    timestamp
+    owner
+    amount0
+    amount1
+    amountUSD
+    tickLower
+    tickUpper
+    logIndex
+  }
+}

--- a/packages/uni-info-watcher/test/queries/factories.gql
+++ b/packages/uni-info-watcher/test/queries/factories.gql
@@ -10,5 +10,8 @@ query factories($block: Block_height){
     totalVolumeETH
     untrackedVolumeUSD
     totalValueLockedETH
+    totalValueLockedUSDUntracked
+    totalValueLockedETHUntracked
+    owner
   }
 }

--- a/packages/uni-info-watcher/test/queries/flashes.gql
+++ b/packages/uni-info-watcher/test/queries/flashes.gql
@@ -1,0 +1,20 @@
+query flashes($block: Block_height){
+  flashes(block: $block){
+    id
+    transaction {
+      id
+    }
+    pool {
+      id
+    }
+    timestamp
+    sender
+    recipient
+    amount0
+    amount1
+    amountUSD
+    amount0Paid
+    amount1Paid
+    logIndex
+  }
+}

--- a/packages/uni-info-watcher/test/queries/mints.gql
+++ b/packages/uni-info-watcher/test/queries/mints.gql
@@ -23,5 +23,6 @@ query mints($block: Block_height){
     }
     tickLower
     tickUpper
+    logIndex
   }
 }

--- a/packages/uni-info-watcher/test/queries/poolDayDatas.gql
+++ b/packages/uni-info-watcher/test/queries/poolDayDatas.gql
@@ -20,7 +20,9 @@ query poolDayDatas($block: Block_height){
     token1Price
     volumeToken0
     volumeToken1
-    feeGrowthGlobal0X128
-    feeGrowthGlobal1X128
+
+    # Skipping fee growth as they are not queried.
+    # feeGrowthGlobal0X128
+    # feeGrowthGlobal1X128
   }
 }

--- a/packages/uni-info-watcher/test/queries/poolHourDatas.gql
+++ b/packages/uni-info-watcher/test/queries/poolHourDatas.gql
@@ -1,0 +1,26 @@
+query poolHourDatas($block: Block_height){
+  poolHourDatas(block: $block){
+    id
+    pool {
+      id
+    }
+    periodStartUnix
+    high
+    low
+    open
+    close
+    sqrtPrice
+    tick
+    liquidity
+    feeGrowthGlobal0X128
+    feeGrowthGlobal1X128
+    token0Price
+    token1Price
+    tvlUSD
+    txCount
+    volumeToken0
+    volumeToken1
+    volumeUSD
+    feesUSD
+  }
+}

--- a/packages/uni-info-watcher/test/queries/poolHourDatas.gql
+++ b/packages/uni-info-watcher/test/queries/poolHourDatas.gql
@@ -12,8 +12,6 @@ query poolHourDatas($block: Block_height){
     sqrtPrice
     tick
     liquidity
-    feeGrowthGlobal0X128
-    feeGrowthGlobal1X128
     token0Price
     token1Price
     tvlUSD
@@ -22,5 +20,9 @@ query poolHourDatas($block: Block_height){
     volumeToken1
     volumeUSD
     feesUSD
+
+    # Skipping fee growth as they are not queried.
+    # feeGrowthGlobal0X128
+    # feeGrowthGlobal1X128
   }
 }

--- a/packages/uni-info-watcher/test/queries/pools.gql
+++ b/packages/uni-info-watcher/test/queries/pools.gql
@@ -25,5 +25,13 @@ query pools($block: Block_height){
     totalValueLockedETH
     feeGrowthGlobal0X128
     feeGrowthGlobal1X128
+    createdAtTimestamp
+    createdAtBlockNumber
+    observationIndex
+    collectedFeesToken0
+    collectedFeesToken1
+    collectedFeesUSD
+    totalValueLockedUSDUntracked
+    liquidityProviderCount
   }
 }

--- a/packages/uni-info-watcher/test/queries/pools.gql
+++ b/packages/uni-info-watcher/test/queries/pools.gql
@@ -23,8 +23,6 @@ query pools($block: Block_height){
     volumeToken1
     untrackedVolumeUSD
     totalValueLockedETH
-    feeGrowthGlobal0X128
-    feeGrowthGlobal1X128
     createdAtTimestamp
     createdAtBlockNumber
     observationIndex
@@ -33,5 +31,9 @@ query pools($block: Block_height){
     collectedFeesUSD
     totalValueLockedUSDUntracked
     liquidityProviderCount
+
+    # Skipping fee growth as they are not queried.
+    # feeGrowthGlobal0X128
+    # feeGrowthGlobal1X128
   }
 }

--- a/packages/uni-info-watcher/test/queries/positionSnapshots.gql
+++ b/packages/uni-info-watcher/test/queries/positionSnapshots.gql
@@ -1,0 +1,26 @@
+query positionSnapshots($block: Block_height){
+  positionSnapshots(block: $block){
+    id
+    timestamp
+    feeGrowthInside0LastX128
+    feeGrowthInside1LastX128
+    liquidity
+    depositedToken0
+    depositedToken1
+    owner
+    withdrawnToken0
+    withdrawnToken1
+    collectedFeesToken0
+    collectedFeesToken1
+    blockNumber
+    pool {
+      id
+    }
+    position{
+      id
+    }
+    transaction{
+      id
+    }
+  }
+}

--- a/packages/uni-info-watcher/test/queries/swaps.gql
+++ b/packages/uni-info-watcher/test/queries/swaps.gql
@@ -22,5 +22,6 @@ query swaps($block: Block_height){
     recipient
     sqrtPriceX96
     tick
+    logIndex
   }
 }

--- a/packages/uni-info-watcher/test/queries/tickDayDatas.gql
+++ b/packages/uni-info-watcher/test/queries/tickDayDatas.gql
@@ -1,0 +1,20 @@
+query tickDayDatas($block: Block_height){
+  tickDayDatas(block: $block){
+    id
+    pool {
+      id
+    }
+    tick {
+      id
+    }
+    date
+    liquidityGross
+    liquidityNet
+    volumeToken0
+    volumeToken1
+    volumeUSD
+    feesUSD
+    feeGrowthOutside0X128
+    feeGrowthOutside1X128
+  }
+}

--- a/packages/uni-info-watcher/test/queries/tickHourDatas.gql
+++ b/packages/uni-info-watcher/test/queries/tickHourDatas.gql
@@ -1,0 +1,18 @@
+query tickHourDatas($block: Block_height){
+  tickHourDatas(block: $block){
+    id
+    pool {
+      id
+    }
+    tick {
+      id
+    }
+    liquidityGross
+    liquidityNet
+    periodStartUnix
+    volumeToken0
+    volumeToken1
+    volumeUSD
+    feesUSD
+  }
+}

--- a/packages/uni-info-watcher/test/queries/ticks.gql
+++ b/packages/uni-info-watcher/test/queries/ticks.gql
@@ -6,5 +6,22 @@ query ticks($block: Block_height){
     price0
     price1
     tickIdx
+    poolAddress
+    pool {
+      id
+    }
+    volumeToken0
+    volumeToken1
+    volumeUSD
+    untrackedVolumeUSD
+    feesUSD
+    collectedFeesToken0
+    collectedFeesToken1
+    collectedFeesUSD
+    createdAtTimestamp
+    createdAtBlockNumber
+    liquidityProviderCount
+    feeGrowthOutside0X128
+    feeGrowthOutside1X128
   }
 }

--- a/packages/uni-info-watcher/test/queries/tokens.gql
+++ b/packages/uni-info-watcher/test/queries/tokens.gql
@@ -15,5 +15,7 @@ query tokens($block: Block_height){
       id
     }
     untrackedVolumeUSD
+    poolCount
+    totalValueLockedUSDUntracked
   }
 }

--- a/packages/uni-info-watcher/test/queries/transactions.gql
+++ b/packages/uni-info-watcher/test/queries/transactions.gql
@@ -11,5 +11,8 @@ query transactions($block: Block_height){
       id
     }
     timestamp
+    blockNumber
+    gasUsed
+    gasPrice
   }
 }

--- a/packages/uni-info-watcher/test/queries/uniswapDayDatas.gql
+++ b/packages/uni-info-watcher/test/queries/uniswapDayDatas.gql
@@ -7,5 +7,7 @@ query uniswapDayDatas($block: Block_height){
     feesUSD
     txCount
     volumeETH
+    volumeUSDUntracked
+
   }
 }

--- a/packages/uni-watcher/src/client.ts
+++ b/packages/uni-watcher/src/client.ts
@@ -14,7 +14,10 @@ import {
   queryGetContract,
   queryEventsInRange,
   queryCallGetPool,
-  queryPositions
+  queryPositions,
+  queryTicks,
+  queryFeeGrowthGlobal0X128,
+  queryFeeGrowthGlobal1X128
 } from './queries';
 
 export class Client {
@@ -112,6 +115,43 @@ export class Client {
     );
 
     return positions;
+  }
+
+  async ticks (blockHash: string, contractAddress: string, tick: number): Promise<any> {
+    const { ticks } = await this._client.query(
+      gql(queryTicks),
+      {
+        blockHash,
+        contractAddress,
+        tick
+      }
+    );
+
+    return ticks;
+  }
+
+  async feeGrowthGlobal0X128 (blockHash: string, contractAddress: string): Promise<any> {
+    const { feeGrowthGlobal0X128 } = await this._client.query(
+      gql(queryFeeGrowthGlobal0X128),
+      {
+        blockHash,
+        contractAddress
+      }
+    );
+
+    return feeGrowthGlobal0X128;
+  }
+
+  async feeGrowthGlobal1X128 (blockHash: string, contractAddress: string): Promise<any> {
+    const { feeGrowthGlobal1X128 } = await this._client.query(
+      gql(queryFeeGrowthGlobal1X128),
+      {
+        blockHash,
+        contractAddress
+      }
+    );
+
+    return feeGrowthGlobal1X128;
   }
 
   async getContract (type: string): Promise<any> {

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -227,6 +227,20 @@ export class Indexer implements IndexerInterface {
 
             break;
           }
+          case 'Flash': {
+            eventName = logDescription.name;
+            const { sender, recipient, amount0, amount1, paid0, paid1 } = logDescription.args;
+            eventInfo = {
+              sender,
+              recipient,
+              amount0: amount0.toString(),
+              amount1: amount1.toString(),
+              paid0: paid0.toString(),
+              paid1: paid1.toString()
+            };
+
+            break;
+          }
         }
 
         break;
@@ -351,6 +365,63 @@ export class Indexer implements IndexerInterface {
 
     try {
       const value = await contract.positions(tokenId, { blockTag: blockHash });
+
+      return { value };
+    } catch (error: any) {
+      if (error.code === ethers.utils.Logger.errors.CALL_EXCEPTION) {
+        log('eth_call error');
+        log(error);
+
+        throw new Error(error.code);
+      }
+
+      throw error;
+    }
+  }
+
+  async ticks (blockHash: string, contractAddress: string, tick: number): Promise<ValueResult> {
+    const contract = new ethers.Contract(contractAddress, poolABI, this._ethProvider);
+
+    try {
+      const value = await contract.ticks(tick, { blockTag: blockHash });
+
+      return { value };
+    } catch (error: any) {
+      if (error.code === ethers.utils.Logger.errors.CALL_EXCEPTION) {
+        log('eth_call error');
+        log(error);
+
+        throw new Error(error.code);
+      }
+
+      throw error;
+    }
+  }
+
+  async feeGrowthGlobal0X128 (blockHash: string, contractAddress: string): Promise<ValueResult> {
+    const contract = new ethers.Contract(contractAddress, poolABI, this._ethProvider);
+
+    try {
+      const value = await contract.feeGrowthGlobal0X128({ blockTag: blockHash });
+
+      return { value };
+    } catch (error: any) {
+      if (error.code === ethers.utils.Logger.errors.CALL_EXCEPTION) {
+        log('eth_call error');
+        log(error);
+
+        throw new Error(error.code);
+      }
+
+      throw error;
+    }
+  }
+
+  async feeGrowthGlobal1X128 (blockHash: string, contractAddress: string): Promise<ValueResult> {
+    const contract = new ethers.Contract(contractAddress, poolABI, this._ethProvider);
+
+    try {
+      const value = await contract.feeGrowthGlobal1X128({ blockTag: blockHash });
 
       return { value };
     } catch (error: any) {

--- a/packages/uni-watcher/src/queries.ts
+++ b/packages/uni-watcher/src/queries.ts
@@ -196,6 +196,49 @@ query callGetPool($blockHash: String!, $contractAddress: String!, $key0: String!
 }
 `;
 
+export const queryTicks = gql`
+query ticks($blockHash: String!, $contractAddress: String!, $tick: Int!) {
+  ticks(blockHash: $blockHash, contractAddress: $contractAddress, tick: $tick) {
+    value {
+      liquidityGross
+      liquidityNet
+      feeGrowthOutside0X128
+      feeGrowthOutside1X128
+      tickCumulativeOutside
+      secondsPerLiquidityOutsideX128
+      secondsOutside
+      initialized
+    }
+
+    proof {
+      data
+    }
+  }
+}
+`;
+
+export const queryFeeGrowthGlobal0X128 = gql`
+query feeGrowthGlobal0X128($blockHash: String!, $contractAddress: String!) {
+  feeGrowthGlobal0X128(blockHash: $blockHash, contractAddress: $contractAddress) {
+    value
+    proof {
+      data
+    }
+  }
+}
+`;
+
+export const queryFeeGrowthGlobal1X128 = gql`
+query feeGrowthGlobal1X128($blockHash: String!, $contractAddress: String!) {
+  feeGrowthGlobal1X128(blockHash: $blockHash, contractAddress: $contractAddress) {
+    value
+    proof {
+      data
+    }
+  }
+}
+`;
+
 export const queryGetContract = gql`
 query queryGetContract($type: String!) {
   getContract(type: $type) {

--- a/packages/uni-watcher/src/resolvers.ts
+++ b/packages/uni-watcher/src/resolvers.ts
@@ -101,6 +101,30 @@ export const createResolvers = async (indexer: Indexer, eventWatcher: EventWatch
         return indexer.positions(blockHash, contractAddress, tokenId);
       },
 
+      ticks: (_: any, { blockHash, contractAddress, tick }: { blockHash: string, contractAddress: string, tick: number }): Promise<ValueResult> => {
+        log('ticks', blockHash, contractAddress, tick);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('ticks').inc(1);
+
+        return indexer.ticks(blockHash, contractAddress, tick);
+      },
+
+      feeGrowthGlobal0X128: (_: any, { blockHash, contractAddress }: { blockHash: string, contractAddress: string }): Promise<ValueResult> => {
+        log('feeGrowthGlobal0X128', blockHash, contractAddress);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('feeGrowthGlobal0X128').inc(1);
+
+        return indexer.feeGrowthGlobal0X128(blockHash, contractAddress);
+      },
+
+      feeGrowthGlobal1X128: (_: any, { blockHash, contractAddress }: { blockHash: string, contractAddress: string }): Promise<ValueResult> => {
+        log('feeGrowthGlobal1X128', blockHash, contractAddress);
+        gqlTotalQueryCount.inc(1);
+        gqlQueryCount.labels('feeGrowthGlobal1X128').inc(1);
+
+        return indexer.feeGrowthGlobal1X128(blockHash, contractAddress);
+      },
+
       poolIdToPoolKey: (_: any, { blockHash, poolId }: { blockHash: string, poolId: string }) => {
         log('poolIdToPoolKey', blockHash, poolId);
         gqlTotalQueryCount.inc(1);

--- a/packages/uni-watcher/src/schema.ts
+++ b/packages/uni-watcher/src/schema.ts
@@ -134,6 +134,23 @@ type TransferEvent {
 # All events emitted by the NonfungiblePositionManager contract.
 union NonFungiblePositionManagerEvent = IncreaseLiquidityEvent | DecreaseLiquidityEvent | CollectEvent | TransferEvent
 
+# Pool Types
+
+type TicksValue {
+  liquidityGross: BigInt!
+  liquidityNet: BigInt!
+  feeGrowthOutside0X128: BigInt!
+  feeGrowthOutside1X128: BigInt!
+  tickCumulativeOutside: BigInt!
+  secondsPerLiquidityOutsideX128: BigInt!
+  secondsOutside: Int!
+  initialized: Boolean!
+}
+
+type ResultTicks {
+  value: TicksValue!
+  proof: Proof
+}
 
 # Pool Events
 
@@ -175,11 +192,20 @@ type SwapEvent {
   tick: BigInt!
 }
 
-union PoolEvent = InitializeEvent | MintEvent | BurnEvent | SwapEvent
+type FlashEvent {
+  sender: String!
+  recipient: String!
+  amount0: BigInt!
+  amount1: BigInt!
+  paid0: BigInt!
+  paid1: BigInt!
+}
+
+union PoolEvent = InitializeEvent | MintEvent | BurnEvent | SwapEvent | FlashEvent
 
 
 # All events emitted by the watcher.
-union Event = TransferEvent | PoolCreatedEvent | IncreaseLiquidityEvent | DecreaseLiquidityEvent | CollectEvent | InitializeEvent | MintEvent | BurnEvent | SwapEvent
+union Event = TransferEvent | PoolCreatedEvent | IncreaseLiquidityEvent | DecreaseLiquidityEvent | CollectEvent | InitializeEvent | MintEvent | BurnEvent | SwapEvent | FlashEvent
 
 # Ethereum types
 
@@ -274,13 +300,21 @@ type Query {
 
   # Pool
 
+  ticks(
+    blockHash: String!,
+    contractAddress: String!,
+    tick: Int!
+  ): ResultTicks!
+
   feeGrowthGlobal0X128(
-    blockHash: String!
+    blockHash: String!,
+    contractAddress: String!,
   ): ResultUInt256!
 
   # Pool (feeGrowthGlobal1X128)
   feeGrowthGlobal1X128(
-    blockHash: String!
+    blockHash: String!,
+    contractAddress: String!,
   ): ResultUInt256!
 
   # Get uniswap events at a certain block, optionally filter by event name.

--- a/packages/util/src/graph-decimal.ts
+++ b/packages/util/src/graph-decimal.ts
@@ -30,7 +30,8 @@ export class GraphDecimal {
   }
 
   toJSON (): string {
-    return this.toString();
+    // Using fixed-point notation in preparing entity state.
+    return this.toFixed();
   }
 
   toFixed (): string {


### PR DESCRIPTION
Part of https://github.com/vulcanize/uniswap-watcher-ts/issues/367

- Add back entities and fields that were omitted for not being used in uniswap frontend app
