### PR TITLE
Save block to the db while fetching events

### DIFF
--- a/packages/erc20-watcher/src/fill.ts
+++ b/packages/erc20-watcher/src/fill.ts
@@ -75,7 +75,7 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
@@ -89,6 +89,7 @@ export const main = async (): Promise<any> => {
   // Later: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries
   const pubsub = new PubSub();
 
+  assert(jobQueueConfig, 'Missing job queue config');
   const { dbConnectionString, maxCompletionLagInSecs } = jobQueueConfig;
   assert(dbConnectionString, 'Missing job queue db connection string');
 
@@ -99,9 +100,7 @@ export const main = async (): Promise<any> => {
 
   const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
 
-  assert(jobQueueConfig, 'Missing job queue config');
-
-  await fillBlocks(jobQueue, indexer, eventWatcher, blockDelayInMilliSecs, argv);
+  await fillBlocks(jobQueue, indexer, eventWatcher, jobQueueConfig.blockDelayInMilliSecs, argv);
 };
 
 main().catch(err => {

--- a/packages/uni-info-watcher/environments/test.toml
+++ b/packages/uni-info-watcher/environments/test.toml
@@ -19,7 +19,6 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8545"
-    blockDelayInMilliSecs = 2000
 
   [upstream.cache]
     name = "requests"
@@ -39,3 +38,4 @@
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 1000
   eventsInBatch = 50
+  blockDelayInMilliSecs = 2000

--- a/packages/uni-info-watcher/src/cli/import-state.ts
+++ b/packages/uni-info-watcher/src/cli/import-state.ts
@@ -86,7 +86,7 @@ export const main = async (): Promise<any> => {
     jobQueue,
     indexer,
     eventWatcher,
-    config.upstream.ethServer.blockDelayInMilliSecs,
+    jobQueueConfig.blockDelayInMilliSecs,
     {
       prefetch: true,
       startBlock: importData.snapshotBlock.blockNumber,

--- a/packages/uni-info-watcher/src/fill.ts
+++ b/packages/uni-info-watcher/src/fill.ts
@@ -83,7 +83,7 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig, uniWatcher, tokenWatcher } = upstream;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig, uniWatcher, tokenWatcher } = upstream;
 
   const cache = await getCache(cacheConfig);
 
@@ -117,7 +117,7 @@ export const main = async (): Promise<any> => {
 
   const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
 
-  await fillBlocks(jobQueue, indexer, eventWatcher, blockDelayInMilliSecs, argv);
+  await fillBlocks(jobQueue, indexer, eventWatcher, jobQueueConfig.blockDelayInMilliSecs, argv);
 };
 
 main().catch(err => {

--- a/packages/uni-watcher/environments/test.toml
+++ b/packages/uni-watcher/environments/test.toml
@@ -16,7 +16,6 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8545"
-    blockDelayInMilliSecs = 2000
 
   [upstream.cache]
     name = "requests"
@@ -28,3 +27,4 @@
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 100
   eventsInBatch = 50
+  blockDelayInMilliSecs = 2000

--- a/packages/uni-watcher/src/fill.ts
+++ b/packages/uni-watcher/src/fill.ts
@@ -75,7 +75,7 @@ export const main = async (): Promise<any> => {
   await db.init();
 
   assert(upstream, 'Missing upstream config');
-  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint, blockDelayInMilliSecs }, cache: cacheConfig } = upstream;
+  const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
 
   const cache = await getCache(cacheConfig);
   const ethClient = new EthClient({
@@ -89,6 +89,7 @@ export const main = async (): Promise<any> => {
   // Later: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#production-pubsub-libraries
   const pubsub = new PubSub();
 
+  assert(jobQueueConfig, 'Missing job queue config');
   const { dbConnectionString, maxCompletionLagInSecs } = jobQueueConfig;
   assert(dbConnectionString, 'Missing job queue db connection string');
 
@@ -100,9 +101,7 @@ export const main = async (): Promise<any> => {
 
   const eventWatcher = new EventWatcher(upstream, ethClient, indexer, pubsub, jobQueue);
 
-  assert(jobQueueConfig, 'Missing job queue config');
-
-  await fillBlocks(jobQueue, indexer, eventWatcher, blockDelayInMilliSecs, argv);
+  await fillBlocks(jobQueue, indexer, eventWatcher, jobQueueConfig.blockDelayInMilliSecs, argv);
 };
 
 main().catch(err => {

--- a/packages/uni-watcher/src/smoke.test.ts
+++ b/packages/uni-watcher/src/smoke.test.ts
@@ -129,7 +129,7 @@ describe('uni-watcher', () => {
     // Verifying with the db.
     const indexer = new Indexer(config.server, db, ethClient, ethProvider, jobQueue);
     await indexer.init();
-    assert(await indexer.isWatchedContract(factory.address), 'Factory contract not added to the database.');
+    assert(indexer.isWatchedContract(factory.address), 'Factory contract not added to the database.');
   });
 
   it('should deploy 2 tokens', async () => {

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -33,7 +33,6 @@ export interface UpstreamConfig {
   ethServer: {
     gqlApiEndpoint: string;
     rpcProviderEndpoint: string;
-    blockDelayInMilliSecs: number;
   }
   traceProviderEndpoint: string;
   uniWatcher: {

--- a/packages/util/src/fill.ts
+++ b/packages/util/src/fill.ts
@@ -14,6 +14,8 @@ const log = debug('vulcanize:fill');
 
 export const DEFAULT_PREFETCH_BATCH_SIZE = 10;
 
+// TODO: Use from @vulcanize/util (watcher-ts)
+
 export const fillBlocks = async (
   jobQueue: JobQueue,
   indexer: IndexerInterface,
@@ -134,18 +136,7 @@ const prefetchBlocks = async (
       const blockProgress = await indexer.getBlockProgress(blockHash);
 
       if (!blockProgress) {
-        const events = await indexer.fetchBlockEvents({ blockHash });
-
-        // Save block progress in database.
-        await indexer.saveBlockProgress({
-          cid,
-          blockHash,
-          blockNumber,
-          parentHash,
-          blockTimestamp: timestamp,
-          numEvents: events.length,
-          isComplete: events.length === 0
-        });
+        await indexer.saveBlockAndFetchEvents({ cid, blockHash, blockNumber, parentHash, blockTimestamp: timestamp });
 
         // In fill prefetch, not saving events to database as now events are saved after processing them in job-runner.
         // Saving them in fill prefetch will result to error when events get saved after processing.

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -54,7 +54,6 @@ export interface ContractInterface {
 }
 
 export interface IndexerInterface extends BaseIndexerInterface {
-  fetchBlockEvents (block: DeepPartial<BlockProgressInterface>): Promise<DeepPartial<EventInterface>[]>
   saveBlockProgress (block: DeepPartial<BlockProgressInterface>): Promise<BlockProgressInterface>
   saveEvents (dbEvents: EventInterface[]): Promise<void>
 }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/190
Follows https://github.com/cerc-io/watcher-ts/pull/206

- Save block to the database while fetching events to match behavior in other watchers
- Remove `blockDelayInMilliSecs` from `upstream` config - present in `jobQueue` config