### PR TITLE
Update API usage to get block events and transactions

### DIFF
--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -515,8 +515,9 @@ export class Indexer implements IndexerInterface {
     parentHash
   }: DeepPartial<BlockProgress>): Promise<[BlockProgress, DeepPartial<Event>[]]> {
     assert(blockHash);
+    assert(blockNumber);
 
-    const dbEvents = await this._baseIndexer.fetchEvents(blockHash, this.parseEventNameAndArgs.bind(this));
+    const dbEvents = await this._baseIndexer.fetchEvents(blockHash, blockNumber, this.parseEventNameAndArgs.bind(this));
 
     const block = {
       id,

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -26,8 +26,7 @@ import {
   eventProcessingEthCallDuration,
   getFullTransaction,
   getFullBlock,
-  StateKind,
-  cachePrunedEntitiesCount
+  StateKind
 } from '@cerc-io/util';
 import { EthClient } from '@cerc-io/ipld-eth-client';
 import { StorageLayout, MappingKey } from '@cerc-io/solidity-mapper';
@@ -611,6 +610,7 @@ export class Indexer implements IndexerInterface {
     parentHash
   }: DeepPartial<BlockProgress>): Promise<[BlockProgress, DeepPartial<Event>[]]> {
     assert(blockHash);
+    assert(blockNumber);
 
     const events = await this._uniClient.getEvents(blockHash);
 
@@ -624,7 +624,7 @@ export class Indexer implements IndexerInterface {
 
     await Promise.all(
       Array.from(txHashSet).map(async (txHash: any) => {
-        const transaction = await getFullTransaction(this._ethClient, txHash);
+        const transaction = await getFullTransaction(this._ethClient, txHash, blockNumber);
         transactionsMap.set(txHash, transaction);
       })
     );

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -559,9 +559,10 @@ export class Indexer implements IndexerInterface {
     parentHash
   }: DeepPartial<BlockProgress>): Promise<[BlockProgress, DeepPartial<Event>[]]> {
     assert(blockHash);
+    assert(blockNumber);
 
     // serverConfig.filterLogs should not be set to allow fetching unknown events
-    const dbEvents = await this._baseIndexer.fetchEvents(blockHash, this.parseEventNameAndArgs.bind(this));
+    const dbEvents = await this._baseIndexer.fetchEvents(blockHash, blockNumber, this.parseEventNameAndArgs.bind(this));
 
     const block = {
       id,


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/190
Follows https://github.com/cerc-io/watcher-ts/pull/210

- Pass block number when fetching events and transactions in a block