### PR TITLE
Update API usage to get full block data

### DIFF
--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -685,7 +685,7 @@ export class Indexer implements IndexerInterface {
     const { __typename: eventName } = event;
 
     if (!this._fullBlock || (this._fullBlock.hash !== block.hash)) {
-      const { blockHash, blockNumber, timestamp, ...blockData } = await getFullBlock(this._ethClient, this._ethProvider, block.hash);
+      const { blockHash, blockNumber, timestamp, ...blockData } = await getFullBlock(this._ethClient, this._ethProvider, block.hash, block.number);
 
       this._fullBlock = {
         hash: blockHash,


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/190
Follows https://github.com/cerc-io/watcher-ts/pull/213

- Pass block number when fetching full block data