### PR TITLE
Denormalize is_pruned flag

### DIFF
--- a/packages/uni-info-watcher/package.json
+++ b/packages/uni-info-watcher/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.3.19",
+    "@types/lodash": "^4.14.168",
     "@ipld/dag-cbor": "^6.0.12",
     "@vulcanize/cache": "^0.1.0",
     "@vulcanize/erc20-watcher": "^0.1.0",
@@ -23,6 +24,7 @@
     "json-bigint": "^1.0.0",
     "reflect-metadata": "^0.1.13",
     "typeorm": "^0.2.32",
+    "lodash": "^4.17.21",
     "yargs": "^17.0.1"
   },
   "scripts": {
@@ -75,7 +77,6 @@
     "ethers": "^5.2.0",
     "get-graphql-schema": "^2.1.2",
     "graphql-schema-linter": "^2.0.1",
-    "lodash": "^4.17.21",
     "mocha": "^8.4.0",
     "nodemon": "^2.0.7",
     "pprof": "^3.2.0",

--- a/packages/uni-info-watcher/src/entity/Bundle.ts
+++ b/packages/uni-info-watcher/src/entity/Bundle.ts
@@ -20,4 +20,7 @@ export class Bundle {
 
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   ethPriceUSD!: GraphDecimal
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Burn.ts
+++ b/packages/uni-info-watcher/src/entity/Burn.ts
@@ -62,4 +62,7 @@ export class Burn {
   // Field is nullable to work with old DB schema.
   @Column('numeric', { nullable: true, transformer: bigintTransformer })
   logIndex!: bigint
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Collect.ts
+++ b/packages/uni-info-watcher/src/entity/Collect.ts
@@ -46,4 +46,7 @@ export class Collect {
 
   @Column('numeric', { nullable: true, transformer: bigintTransformer })
   logIndex!: bigint
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Factory.ts
+++ b/packages/uni-info-watcher/src/entity/Factory.ts
@@ -54,4 +54,7 @@ export class Factory {
 
   @Column('varchar', { length: 42, default: ADDRESS_ZERO })
   owner!: string
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Flash.ts
+++ b/packages/uni-info-watcher/src/entity/Flash.ts
@@ -49,4 +49,7 @@ export class Flash {
 
   @Column('numeric', { transformer: bigintTransformer })
   logIndex!: bigint
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Mint.ts
+++ b/packages/uni-info-watcher/src/entity/Mint.ts
@@ -67,4 +67,7 @@ export class Mint {
   // Field is nullable to work with old DB schema.
   @Column('numeric', { nullable: true, transformer: bigintTransformer })
   logIndex!: bigint
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Pool.ts
+++ b/packages/uni-info-watcher/src/entity/Pool.ts
@@ -98,6 +98,9 @@ export class Pool {
   @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
   liquidityProviderCount!: bigint
 
+  @Column('boolean', { default: false })
+  isPruned!: boolean
+
   // Skipping fee growth as they are not queried.
   // @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
   // feeGrowthGlobal0X128!: bigint

--- a/packages/uni-info-watcher/src/entity/PoolDayData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolDayData.ts
@@ -70,6 +70,9 @@ export class PoolDayData {
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
 
+  @Column('boolean', { default: false })
+  isPruned!: boolean
+
   // Skipping fee growth as they are not queried.
   // @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
   // feeGrowthGlobal0X128!: bigint

--- a/packages/uni-info-watcher/src/entity/PoolHourData.ts
+++ b/packages/uni-info-watcher/src/entity/PoolHourData.ts
@@ -69,6 +69,9 @@ export class PoolHourData {
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
 
+  @Column('boolean', { default: false })
+  isPruned!: boolean
+
   // Skipping fee growth as they are not queried.
   // @Column('numeric', { default: BigInt(0), transformer: bigintTransformer })
   // feeGrowthGlobal0X128!: bigint

--- a/packages/uni-info-watcher/src/entity/Position.ts
+++ b/packages/uni-info-watcher/src/entity/Position.ts
@@ -67,4 +67,7 @@ export class Position {
 
   @Column('varchar')
   transaction!: string;
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/PositionSnapshot.ts
+++ b/packages/uni-info-watcher/src/entity/PositionSnapshot.ts
@@ -65,4 +65,7 @@ export class PositionSnapshot {
 
   @Column('varchar')
   transaction!: string
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Swap.ts
+++ b/packages/uni-info-watcher/src/entity/Swap.ts
@@ -9,7 +9,6 @@ import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulca
 @Index(['id', 'blockNumber'])
 @Index(['transaction'])
 @Index(['timestamp'])
-@Index(['blockHash', 'blockNumber'])
 export class Swap {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/entity/Swap.ts
+++ b/packages/uni-info-watcher/src/entity/Swap.ts
@@ -9,6 +9,7 @@ import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulca
 @Index(['id', 'blockNumber'])
 @Index(['transaction'])
 @Index(['timestamp'])
+@Index(['blockHash', 'blockNumber'])
 export class Swap {
   @PrimaryColumn('varchar')
   id!: string;
@@ -62,4 +63,7 @@ export class Swap {
   // Field is nullable to work with old DB schema.
   @Column('numeric', { nullable: true, transformer: bigintTransformer })
   logIndex!: bigint
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Tick.ts
+++ b/packages/uni-info-watcher/src/entity/Tick.ts
@@ -79,4 +79,7 @@ export class Tick {
 
   @Column('numeric', { default: 0, transformer: bigintTransformer })
   feeGrowthOutside1X128!: bigint
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/TickDayData.ts
+++ b/packages/uni-info-watcher/src/entity/TickDayData.ts
@@ -54,4 +54,7 @@ export class TickDayData {
 
   @Column('numeric', { default: 0, transformer: bigintTransformer })
   feeGrowthOutside1X128!: bigint
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/TickHourData.ts
+++ b/packages/uni-info-watcher/src/entity/TickHourData.ts
@@ -44,4 +44,7 @@ export class TickHourData {
 
   @Column('numeric', { transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Token.ts
+++ b/packages/uni-info-watcher/src/entity/Token.ts
@@ -62,4 +62,7 @@ export class Token {
 
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   totalValueLockedUSDUntracked!: GraphDecimal
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/TokenDayData.ts
+++ b/packages/uni-info-watcher/src/entity/TokenDayData.ts
@@ -57,4 +57,7 @@ export class TokenDayData {
 
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/TokenHourData.ts
+++ b/packages/uni-info-watcher/src/entity/TokenHourData.ts
@@ -57,4 +57,7 @@ export class TokenHourData {
 
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   feesUSD!: GraphDecimal
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/Transaction.ts
+++ b/packages/uni-info-watcher/src/entity/Transaction.ts
@@ -33,4 +33,7 @@ export class Transaction {
   // Field is nullable to work with old DB schema.
   @Column('numeric', { nullable: true, transformer: bigintTransformer })
   gasPrice!: bigint
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-info-watcher/src/entity/UniswapDayData.ts
+++ b/packages/uni-info-watcher/src/entity/UniswapDayData.ts
@@ -38,4 +38,7 @@ export class UniswapDayData {
 
   @Column('numeric', { default: 0, transformer: graphDecimalTransformer })
   volumeUSDUntracked!: GraphDecimal
+
+  @Column('boolean', { default: false })
+  isPruned!: boolean
 }

--- a/packages/uni-watcher/src/database.ts
+++ b/packages/uni-watcher/src/database.ts
@@ -217,7 +217,7 @@ export class Database implements DatabaseInterface {
     return this._baseDatabase.updateBlockProgress(repo, block, lastProcessedEventIndex);
   }
 
-  async getEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindConditions<Entity>): Promise<Entity[]> {
+  async getEntities<Entity> (queryRunner: QueryRunner, entity: new () => Entity, findConditions?: FindManyOptions<Entity>): Promise<Entity[]> {
     return this._baseDatabase.getEntities(queryRunner, entity, findConditions);
   }
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/191
Requires https://github.com/cerc-io/watcher-ts/pull/219

- Add `is_pruned` flag to all entity tables
- Update the flag if required once the corresponding block is pruned