### PR TITLE
Improve frontend GQL queries

### DIFF
--- a/packages/uni-info-watcher/src/custom-indexer.ts
+++ b/packages/uni-info-watcher/src/custom-indexer.ts
@@ -4,7 +4,7 @@
 
 import { SelectionNode } from 'graphql';
 import assert from 'assert';
-import { Brackets, QueryRunner, Repository, SelectQueryBuilder } from 'typeorm';
+import { Brackets, FindConditions, LessThanOrEqual, QueryRunner, Repository, SelectQueryBuilder } from 'typeorm';
 
 import { OPERATOR_MAP, Config, QueryOptions, Where, BlockHeight } from '@cerc-io/util';
 import { ENTITY_QUERY_TYPE, resolveEntityFieldConflicts } from '@cerc-io/graph-node';
@@ -41,6 +41,47 @@ export class CustomIndexer {
     this._config = config;
     this._db = db;
     this._indexer = indexer;
+  }
+
+  async getPool (id: string, block: BlockHeight, selections: ReadonlyArray<SelectionNode> = []): Promise<Pool | undefined> {
+    const dbTx = await this._db.createTransactionRunner();
+    let res;
+
+    try {
+      const repo = dbTx.manager.getRepository(Pool);
+      const whereOptions: FindConditions<Pool> = { id };
+
+      if (block.hash) {
+        whereOptions.blockHash = block.hash;
+      }
+
+      if (block.number) {
+        whereOptions.blockNumber = LessThanOrEqual(block.number);
+      }
+
+      let entity = await this._db.getModelEntity(repo, whereOptions);
+
+      if (entity) {
+        [entity] = await this.loadEntitiesRelations(
+          dbTx,
+          block,
+          this._db.relationsMap,
+          Pool,
+          [entity],
+          selections
+        );
+      }
+
+      res = entity;
+      await dbTx.commitTransaction();
+    } catch (error) {
+      await dbTx.rollbackTransaction();
+      throw error;
+    } finally {
+      await dbTx.release();
+    }
+
+    return res;
   }
 
   async getEntities<Entity> (
@@ -146,7 +187,7 @@ export class CustomIndexer {
       return [];
     }
 
-    entities = await this.loadLatestEntitiesRelations(queryRunner, block, relationsMap, entity, entities, selections);
+    entities = await this.loadEntitiesRelations(queryRunner, block, relationsMap, entity, entities, selections);
     // Resolve any field name conflicts in the entity result.
     entities = entities.map(entity => resolveEntityFieldConflicts(entity));
 
@@ -271,7 +312,7 @@ export class CustomIndexer {
     return selectQueryBuilder.getMany();
   }
 
-  async loadLatestEntitiesRelations<Entity> (
+  async loadEntitiesRelations<Entity> (
     queryRunner: QueryRunner,
     block: BlockHeight,
     relationsMap: Map<any, { [key: string]: any }>,

--- a/packages/uni-info-watcher/src/custom-indexer.ts
+++ b/packages/uni-info-watcher/src/custom-indexer.ts
@@ -23,6 +23,8 @@ import { TokenHourData } from './entity/TokenHourData';
 import { LatestTokenHourData } from './entity/LatestTokenHourData';
 import { PoolDayData } from './entity/PoolDayData';
 import { LatestPoolDayData } from './entity/LatestPoolDayData';
+import { Tick } from './entity/Tick';
+import { LatestTick } from './entity/LatestTick';
 
 export const entityToLatestEntityMap: Map<any, any> = new Map();
 entityToLatestEntityMap.set(Pool, LatestPool);
@@ -31,6 +33,7 @@ entityToLatestEntityMap.set(UniswapDayData, LatestUniswapDayData);
 entityToLatestEntityMap.set(TokenDayData, LatestTokenDayData);
 entityToLatestEntityMap.set(TokenHourData, LatestTokenHourData);
 entityToLatestEntityMap.set(PoolDayData, LatestPoolDayData);
+entityToLatestEntityMap.set(Tick, LatestTick);
 
 export class CustomIndexer {
   _config: Config;

--- a/packages/uni-info-watcher/src/entity/LatestTick.ts
+++ b/packages/uni-info-watcher/src/entity/LatestTick.ts
@@ -3,10 +3,11 @@
 //
 
 import { Entity, PrimaryColumn, Column, Index } from 'typeorm';
+import { bigintTransformer } from '@vulcanize/util';
 
 @Entity()
 @Index(['id', 'blockHash'])
-export class LatestUniswapDayData {
+export class LatestTick {
   @PrimaryColumn('varchar')
   id!: string;
 
@@ -16,6 +17,9 @@ export class LatestUniswapDayData {
   @Column('integer')
   blockNumber!: number;
 
-  @Column('integer')
-  date!: number
+  @Column('numeric', { transformer: bigintTransformer })
+  tickIdx!: bigint;
+
+  @Column('varchar', { length: 42 })
+  poolAddress!: string
 }

--- a/packages/uni-info-watcher/src/entity/Swap.ts
+++ b/packages/uni-info-watcher/src/entity/Swap.ts
@@ -8,7 +8,9 @@ import { graphDecimalTransformer, GraphDecimal, bigintTransformer } from '@vulca
 @Entity()
 @Index(['id', 'blockNumber'])
 @Index(['transaction'])
-@Index(['timestamp'])
+@Index(['token0', 'timestamp'])
+@Index(['token1', 'timestamp'])
+@Index(['pool', 'timestamp'])
 export class Swap {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/uni-info-watcher/src/resolvers.ts
+++ b/packages/uni-info-watcher/src/resolvers.ts
@@ -165,7 +165,7 @@ export const createResolvers = async (indexer: Indexer, customIndexer: CustomInd
         gqlQueryCount.labels('pool').inc(1);
         assert(info.fieldNodes[0].selectionSet);
 
-        return indexer.getPool(id, block, info.fieldNodes[0].selectionSet.selections);
+        return customIndexer.getPool(id, block, info.fieldNodes[0].selectionSet.selections);
       },
 
       poolDayDatas: async (
@@ -259,7 +259,7 @@ export const createResolvers = async (indexer: Indexer, customIndexer: CustomInd
         gqlQueryCount.labels('ticks').inc(1);
         assert(info.fieldNodes[0].selectionSet);
 
-        return indexer.getEntities(
+        return customIndexer.getEntities(
           Tick,
           block,
           where,


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/191

- Added `token0, timestamp`, `token1, timestamp` and `pool, timestamp` as indexes to swap table
- Use latest entity table query for nested tokens in single `pool` GQL query
- Add latest entity table for `Tick` entity