### PR TITLE
Reset latest and frothy entity tables on watcher reset

### DIFF
--- a/packages/uni-info-watcher/src/cli/reset-cmds/watcher.ts
+++ b/packages/uni-info-watcher/src/cli/reset-cmds/watcher.ts
@@ -3,7 +3,6 @@
 //
 
 import debug from 'debug';
-import { MoreThan } from 'typeorm';
 import assert from 'assert';
 
 import { getConfig, getResetConfig, JobQueue, resetJobs } from '@vulcanize/util';
@@ -12,25 +11,6 @@ import { Client as UniClient } from '@vulcanize/uni-watcher';
 
 import { Database } from '../../database';
 import { Indexer } from '../../indexer';
-import { BlockProgress } from '../../entity/BlockProgress';
-import { Factory } from '../../entity/Factory';
-import { Bundle } from '../../entity/Bundle';
-import { Pool } from '../../entity/Pool';
-import { Mint } from '../../entity/Mint';
-import { Burn } from '../../entity/Burn';
-import { Swap } from '../../entity/Swap';
-import { PositionSnapshot } from '../../entity/PositionSnapshot';
-import { Position } from '../../entity/Position';
-import { Token } from '../../entity/Token';
-import { PoolDayData } from '../../entity/PoolDayData';
-import { PoolHourData } from '../../entity/PoolHourData';
-import { Tick } from '../../entity/Tick';
-import { TickDayData } from '../../entity/TickDayData';
-import { TokenDayData } from '../../entity/TokenDayData';
-import { TokenHourData } from '../../entity/TokenHourData';
-import { Transaction } from '../../entity/Transaction';
-import { UniswapDayData } from '../../entity/UniswapDayData';
-import { Contract } from '../../entity/Contract';
 
 const log = debug('vulcanize:reset-watcher');
 

--- a/packages/uni-info-watcher/src/cli/reset-cmds/watcher.ts
+++ b/packages/uni-info-watcher/src/cli/reset-cmds/watcher.ts
@@ -48,7 +48,7 @@ export const handler = async (argv: any): Promise<void> => {
   const config = await getConfig(argv.configFile);
   await resetJobs(config);
   const { jobQueue: jobQueueConfig } = config;
-  const { dbConfig, serverConfig, upstreamConfig, ethClient, ethProvider } = await getResetConfig(config);
+  const { dbConfig, upstreamConfig, ethClient, ethProvider } = await getResetConfig(config);
 
   // Initialize database.
   const db = new Database(dbConfig);
@@ -73,5 +73,7 @@ export const handler = async (argv: any): Promise<void> => {
   const indexer = new Indexer(config.server, db, uniClient, erc20Client, ethClient, ethProvider, jobQueue);
 
   await indexer.resetWatcherToBlock(argv.blockNumber);
+  await indexer.resetLatestEntities(argv.blockNumber);
+
   log('Reset watcher successfully');
 };

--- a/packages/uni-info-watcher/src/common.ts
+++ b/packages/uni-info-watcher/src/common.ts
@@ -1,0 +1,10 @@
+//
+// Copyright 2022 Vulcanize, Inc.
+//
+
+import { Repository, DeepPartial } from 'typeorm';
+
+export function getLatestEntityFromEntity<Entity> (latestEntityRepo: Repository<Entity>, entity: any): Entity {
+  const latestEntityFields = latestEntityRepo.metadata.columns.map(column => column.propertyName);
+  return latestEntityRepo.create(_.pick(entity, latestEntityFields) as DeepPartial<Entity>);
+}

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -889,11 +889,11 @@ export class Database implements DatabaseInterface {
 
     // Update isPruned flag using fetched entity ids and hashes of blocks to be pruned
     updatePromises.push(
-      [...ENTITIES].map((entity) => {
+      [...ENTITIES].map((entityType) => {
         return this.updateEntity(
           queryRunner,
-          entity as any,
-          { id: In(entityIdsMap.get(entity.name) || []), blockHash: In(blockHashes) },
+          entityType as any,
+          { id: In(entityIdsMap.get(entityType.name) || []), blockHash: In(blockHashes) },
           { isPruned: true }
         );
       }) as any
@@ -909,12 +909,12 @@ export class Database implements DatabaseInterface {
   async updateNonCanonicalLatestEntities (queryRunner: QueryRunner, blockNumber: number, nonCanonicalBlockHashes: string[]): Promise<void> {
     // Update latest entity tables with canonical entries
     await Promise.all(
-      Array.from(entityToLatestEntityMap.entries()).map(async ([entity, latestEntity]) => {
+      Array.from(entityToLatestEntityMap.entries()).map(async ([entityType, latestEntityType]) => {
         // Get entries for non canonical blocks
-        const nonCanonicalLatestEntities = await this.getEntities(queryRunner, latestEntity, { where: { blockHash: In(nonCanonicalBlockHashes) } });
+        const nonCanonicalLatestEntities = await this.getEntities(queryRunner, latestEntityType, { where: { blockHash: In(nonCanonicalBlockHashes) } });
 
         // Canonicalize latest entity table at given block height
-        await this.canonicalizeLatestEntity(queryRunner, entity, latestEntity, nonCanonicalLatestEntities, blockNumber);
+        await this.canonicalizeLatestEntity(queryRunner, entityType, latestEntityType, nonCanonicalLatestEntities, blockNumber);
       })
     );
   }

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -58,6 +58,7 @@ import { Flash } from './entity/Flash';
 import { TickHourData } from './entity/TickHourData';
 import { FrothyEntity } from './entity/FrothyEntity';
 import { entityToLatestEntityMap } from './custom-indexer';
+import { ENTITIES } from './indexer';
 
 const log = debug('vulcanize:database');
 
@@ -96,9 +97,6 @@ export const ENTITY_QUERY_TYPE_MAP = new Map<new() => any, ENTITY_QUERY_TYPE>([
   [TickDayData, ENTITY_QUERY_TYPE.DISTINCT_ON_WITHOUT_PRUNED],
   [UniswapDayData, ENTITY_QUERY_TYPE.GROUP_BY_WITHOUT_PRUNED]
 ]);
-
-export const ENTITIES = new Set([Bundle, Burn, Collect, Factory, Flash, Mint, Pool, PoolDayData, PoolHourData, Position, PositionSnapshot,
-  Swap, Tick, TickDayData, TickHourData, Transaction, UniswapDayData]);
 
 export class Database implements DatabaseInterface {
   _config: ConnectionOptions

--- a/packages/uni-info-watcher/src/entity/Subscriber.ts
+++ b/packages/uni-info-watcher/src/entity/Subscriber.ts
@@ -6,7 +6,7 @@ import { EventSubscriber, EntitySubscriberInterface, InsertEvent, UpdateEvent } 
 import _ from 'lodash';
 
 import { entityToLatestEntityMap } from '../custom-indexer';
-import { ENTITIES } from '../database';
+import { ENTITIES } from '../indexer';
 import { FrothyEntity } from './FrothyEntity';
 
 @EventSubscriber()

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -36,7 +36,7 @@ import { updatePoolDayData, updatePoolHourData, updateTickDayData, updateTokenDa
 import { convertTokenToDecimal, loadFactory, loadTransaction, safeDiv, Block } from './utils';
 import { createTick, feeTierToTickSpacing } from './utils/tick';
 import { ADDRESS_ZERO, FACTORY_ADDRESS, FIRST_GRAFT_BLOCK, WATCHED_CONTRACTS } from './utils/constants';
-import { Database, DEFAULT_LIMIT } from './database';
+import { Database, DEFAULT_LIMIT, ENTITIES } from './database';
 import { Event } from './entity/Event';
 import { ResultEvent, Transaction, PoolCreatedEvent, InitializeEvent, MintEvent, BurnEvent, SwapEvent, IncreaseLiquidityEvent, DecreaseLiquidityEvent, CollectEvent, TransferEvent, FlashEvent } from './events';
 import { Factory } from './entity/Factory';
@@ -49,16 +49,6 @@ import { Swap } from './entity/Swap';
 import { Position } from './entity/Position';
 import { PositionSnapshot } from './entity/PositionSnapshot';
 import { Tick } from './entity/Tick';
-import { PoolDayData } from './entity/PoolDayData';
-import { PoolHourData } from './entity/PoolHourData';
-import { UniswapDayData } from './entity/UniswapDayData';
-import { TokenDayData } from './entity/TokenDayData';
-import { TokenHourData } from './entity/TokenHourData';
-import { TickDayData } from './entity/TickDayData';
-import { Collect } from './entity/Collect';
-import { Flash } from './entity/Flash';
-import { TickHourData } from './entity/TickHourData';
-import { Transaction as TransactionEntity } from './entity/Transaction';
 import { SyncStatus } from './entity/SyncStatus';
 import { BlockProgress } from './entity/BlockProgress';
 import { Contract, KIND_POOL } from './entity/Contract';
@@ -73,8 +63,6 @@ const SYNC_DELTA = 5;
 const log = debug('vulcanize:indexer');
 
 export { OrderDirection, BlockHeight };
-
-export const ENTITIES = new Set([Bundle, Burn, Collect, Factory, Flash, Mint, Pool, PoolDayData, PoolHourData, Position, PositionSnapshot, Swap, Tick, TickDayData, TickHourData, Token, TokenDayData, TokenHourData, TransactionEntity, UniswapDayData]);
 
 export class Indexer implements IndexerInterface {
   _db: Database

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -530,12 +530,12 @@ export class Indexer implements IndexerInterface {
     const dbTx = await this._db.createTransactionRunner();
     try {
       await Promise.all(
-        Array.from(entityToLatestEntityMap.entries()).map(async ([entity, latestEntity]) => {
+        Array.from(entityToLatestEntityMap.entries()).map(async ([entityType, latestEntityType]) => {
           // Get entries above the reset block
-          const entitiesToReset = await this._db.getEntities(dbTx, latestEntity, { where: { blockNumber: MoreThan(blockNumber) } });
+          const entitiesToReset = await this._db.getEntities(dbTx, latestEntityType, { where: { blockNumber: MoreThan(blockNumber) } });
 
           // Canonicalize latest entity table at the reset block height
-          await this._db.canonicalizeLatestEntity(dbTx, entity, latestEntity, entitiesToReset, blockNumber);
+          await this._db.canonicalizeLatestEntity(dbTx, entityType, latestEntityType, entitiesToReset, blockNumber);
         })
       );
 

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -65,12 +65,15 @@ import { Contract, KIND_POOL } from './entity/Contract';
 import { State } from './entity/State';
 import { StateSyncStatus } from './entity/StateSyncStatus';
 import { createInitialState, createStateCheckpoint } from './hooks';
+import { FrothyEntity } from './entity/FrothyEntity';
 
 const SYNC_DELTA = 5;
 
 const log = debug('vulcanize:indexer');
 
 export { OrderDirection, BlockHeight };
+
+export const ENTITIES = new Set([Bundle, Burn, Collect, Factory, Flash, Mint, Pool, PoolDayData, PoolHourData, Position, PositionSnapshot, Swap, Tick, TickDayData, TickHourData, Token, TokenDayData, TokenHourData, TransactionEntity, UniswapDayData]);
 
 export class Indexer implements IndexerInterface {
   _db: Database
@@ -624,7 +627,7 @@ export class Indexer implements IndexerInterface {
   }
 
   async resetWatcherToBlock (blockNumber: number): Promise<void> {
-    const entities = [Factory, Token, Bundle, Pool, Mint, Burn, Swap, Position, PositionSnapshot, Tick, PoolDayData, PoolHourData, UniswapDayData, TokenDayData, TokenHourData, TickDayData, Collect, Flash, TickHourData, TransactionEntity];
+    const entities = [...ENTITIES, FrothyEntity];
     await this._baseIndexer.resetWatcherToBlock(blockNumber, entities);
   }
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/191

- On watcher reset
  - Reset `FrothyEntity` table
  - Reset latest entity tables to reflect latest entities at reset block height