### PR TITLE
Remove graph-node dependency in uniswap-watcher

### DIFF
--- a/packages/erc20-watcher/src/cli/watch-contract.ts
+++ b/packages/erc20-watcher/src/cli/watch-contract.ts
@@ -14,7 +14,8 @@ const log = debug('vulcanize:watch-contract');
 
 const main = async (): Promise<void> => {
   const watchContractCmd = new WatchContractCmd();
-  await watchContractCmd.init(Database, Indexer);
+  await watchContractCmd.init(Database);
+  await watchContractCmd.initIndexer(Indexer);
 
   await watchContractCmd.exec();
 };

--- a/packages/erc20-watcher/src/fill.ts
+++ b/packages/erc20-watcher/src/fill.ts
@@ -15,7 +15,8 @@ const log = debug('vulcanize:server');
 
 export const main = async (): Promise<any> => {
   const fillCmd = new FillCmd();
-  await fillCmd.init(Database, Indexer, EventWatcher);
+  await fillCmd.init(Database);
+  await fillCmd.initIndexer(Indexer, EventWatcher);
 
   await fillCmd.exec();
 };

--- a/packages/erc20-watcher/src/job-runner.ts
+++ b/packages/erc20-watcher/src/job-runner.ts
@@ -19,7 +19,8 @@ export const main = async (): Promise<any> => {
   const jobRunnerCmd = new JobRunnerCmd();
 
   const config: Config = await jobRunnerCmd.initConfig();
-  await jobRunnerCmd.init(Database, Indexer);
+  await jobRunnerCmd.init(Database);
+  await jobRunnerCmd.initIndexer(Indexer);
 
   const jobQueue = jobRunnerCmd.jobQueue;
   const indexer = jobRunnerCmd.indexer as Indexer;

--- a/packages/erc20-watcher/src/server.ts
+++ b/packages/erc20-watcher/src/server.ts
@@ -17,7 +17,8 @@ const log = debug('vulcanize:server');
 
 export const main = async (): Promise<any> => {
   const serverCmd = new ServerCmd();
-  await serverCmd.init(Database, Indexer, EventWatcher);
+  await serverCmd.init(Database);
+  await serverCmd.initIndexer(Indexer, EventWatcher);
 
   return serverCmd.exec(createResolvers, typeDefs);
 };

--- a/packages/uni-info-watcher/src/cli/checkpoint-cmds/create.ts
+++ b/packages/uni-info-watcher/src/cli/checkpoint-cmds/create.ts
@@ -38,7 +38,8 @@ export const handler = async (argv: any): Promise<void> => {
 
   const uniClient = new UniClient(uniWatcher);
   const erc20Client = new ERC20Client(tokenWatcher);
+  await createCheckpointCmd.init(argv, Database, { uniClient, erc20Client });
 
-  await createCheckpointCmd.init(argv, Database, Indexer, { uniClient, erc20Client });
+  await createCheckpointCmd.initIndexer(Indexer);
   await createCheckpointCmd.exec();
 };

--- a/packages/uni-info-watcher/src/cli/export-state.ts
+++ b/packages/uni-info-watcher/src/cli/export-state.ts
@@ -27,7 +27,8 @@ const main = async (): Promise<void> => {
   const uniClient = new UniClient(uniWatcher);
   const erc20Client = new ERC20Client(tokenWatcher);
 
-  await exportStateCmd.init(Database, Indexer, { uniClient, erc20Client });
+  await exportStateCmd.init(Database, { uniClient, erc20Client });
+  await exportStateCmd.initIndexer(Indexer);
   await exportStateCmd.exec();
 };
 

--- a/packages/uni-info-watcher/src/cli/import-state.ts
+++ b/packages/uni-info-watcher/src/cli/import-state.ts
@@ -29,7 +29,8 @@ export const main = async (): Promise<any> => {
   const uniClient = new UniClient(uniWatcher);
   const erc20Client = new ERC20Client(tokenWatcher);
 
-  await importStateCmd.init(Database, Indexer, EventWatcher, { uniClient, erc20Client });
+  await importStateCmd.init(Database, { uniClient, erc20Client });
+  await importStateCmd.initIndexer(Indexer, EventWatcher);
   await importStateCmd.exec(State);
 };
 

--- a/packages/uni-info-watcher/src/cli/inspect-cid.ts
+++ b/packages/uni-info-watcher/src/cli/inspect-cid.ts
@@ -27,7 +27,8 @@ const main = async (): Promise<void> => {
   const uniClient = new UniClient(uniWatcher);
   const erc20Client = new ERC20Client(tokenWatcher);
 
-  await inspectCIDCmd.init(Database, Indexer, { uniClient, erc20Client });
+  await inspectCIDCmd.init(Database, { uniClient, erc20Client });
+  await inspectCIDCmd.initIndexer(Indexer);
   await inspectCIDCmd.exec();
 };
 

--- a/packages/uni-info-watcher/src/cli/reset-cmds/watcher.ts
+++ b/packages/uni-info-watcher/src/cli/reset-cmds/watcher.ts
@@ -32,6 +32,7 @@ export const handler = async (argv: any): Promise<void> => {
   const uniClient = new UniClient(uniWatcher);
   const erc20Client = new ERC20Client(tokenWatcher);
 
-  await resetWatcherCmd.init(argv, Database, Indexer, { uniClient, erc20Client });
+  await resetWatcherCmd.init(argv, Database, { uniClient, erc20Client });
+  await resetWatcherCmd.initIndexer(Indexer);
   await resetWatcherCmd.exec();
 };

--- a/packages/uni-info-watcher/src/cli/watch-contract.ts
+++ b/packages/uni-info-watcher/src/cli/watch-contract.ts
@@ -27,7 +27,8 @@ const main = async (): Promise<void> => {
   const uniClient = new UniClient(uniWatcher);
   const erc20Client = new ERC20Client(tokenWatcher);
 
-  await watchContractCmd.init(Database, Indexer, { uniClient, erc20Client });
+  await watchContractCmd.init(Database, { uniClient, erc20Client });
+  await watchContractCmd.initIndexer(Indexer);
   await watchContractCmd.exec();
 };
 

--- a/packages/uni-info-watcher/src/database.ts
+++ b/packages/uni-info-watcher/src/database.ts
@@ -25,9 +25,10 @@ import {
   BlockHeight,
   QueryOptions,
   Where,
-  ServerConfig
+  ServerConfig,
+  GraphDatabase,
+  ENTITY_QUERY_TYPE
 } from '@cerc-io/util';
-import { Database as GraphDatabase, ENTITY_QUERY_TYPE } from '@cerc-io/graph-node';
 
 import { Factory } from './entity/Factory';
 import { Pool } from './entity/Pool';

--- a/packages/uni-info-watcher/src/entity/Subscriber.ts
+++ b/packages/uni-info-watcher/src/entity/Subscriber.ts
@@ -5,7 +5,7 @@
 import { EventSubscriber, EntitySubscriberInterface, InsertEvent, UpdateEvent } from 'typeorm';
 import _ from 'lodash';
 
-import { afterEntityInsertOrUpdate } from '@cerc-io/graph-node';
+import { afterEntityInsertOrUpdate } from '@cerc-io/util';
 
 import { FrothyEntity } from './FrothyEntity';
 import { ENTITIES, ENTITY_TO_LATEST_ENTITY_MAP } from '../database';

--- a/packages/uni-info-watcher/src/fill.ts
+++ b/packages/uni-info-watcher/src/fill.ts
@@ -29,7 +29,8 @@ export const main = async (): Promise<any> => {
   const uniClient = new UniClient(uniWatcher);
   const erc20Client = new ERC20Client(tokenWatcher);
 
-  await fillCmd.init(Database, Indexer, EventWatcher, { uniClient, erc20Client });
+  await fillCmd.init(Database, { uniClient, erc20Client });
+  await fillCmd.initIndexer(Indexer, EventWatcher);
 
   await fillCmd.exec(getContractEntitiesMap());
 };

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -28,9 +28,10 @@ import {
   JobQueue,
   GraphDecimal,
   DatabaseInterface,
-  Clients
+  Clients,
+  updateSubgraphState,
+  dumpSubgraphState
 } from '@cerc-io/util';
-import { updateSubgraphState, dumpSubgraphState } from '@cerc-io/graph-node';
 import { EthClient } from '@cerc-io/ipld-eth-client';
 import { StorageLayout, MappingKey } from '@cerc-io/solidity-mapper';
 

--- a/packages/uni-info-watcher/src/job-runner.ts
+++ b/packages/uni-info-watcher/src/job-runner.ts
@@ -29,7 +29,8 @@ export const main = async (): Promise<any> => {
   const uniClient = new UniClient(uniWatcher);
   const erc20Client = new ERC20Client(tokenWatcher);
 
-  await jobRunnerCmd.init(Database, Indexer, { uniClient, erc20Client });
+  await jobRunnerCmd.init(Database, { uniClient, erc20Client });
+  await jobRunnerCmd.initIndexer(Indexer);
 
   const jobQueue = jobRunnerCmd.jobQueue;
   const indexer = jobRunnerCmd.indexer as Indexer;

--- a/packages/uni-info-watcher/src/server.ts
+++ b/packages/uni-info-watcher/src/server.ts
@@ -30,7 +30,8 @@ export const main = async (): Promise<any> => {
   const uniClient = new UniClient(uniWatcher);
   const erc20Client = new ERC20Client(tokenWatcher);
 
-  await serverCmd.init(Database, Indexer, EventWatcher, { uniClient, erc20Client });
+  await serverCmd.init(Database, { uniClient, erc20Client });
+  await serverCmd.initIndexer(Indexer, EventWatcher);
 
   return serverCmd.exec(createResolvers, typeDefs);
 };

--- a/packages/uni-watcher/src/cli/reset-cmds/watcher.ts
+++ b/packages/uni-watcher/src/cli/reset-cmds/watcher.ts
@@ -19,7 +19,8 @@ export const builder = {
 
 export const handler = async (argv: any): Promise<void> => {
   const resetWatcherCmd = new ResetWatcherCmd();
-  await resetWatcherCmd.init(argv, Database, Indexer);
+  await resetWatcherCmd.init(argv, Database);
+  await resetWatcherCmd.initIndexer(Indexer);
 
   await resetWatcherCmd.exec();
 };

--- a/packages/uni-watcher/src/cli/watch-contract.ts
+++ b/packages/uni-watcher/src/cli/watch-contract.ts
@@ -14,7 +14,8 @@ const log = debug('vulcanize:watch-contract');
 
 const main = async (): Promise<void> => {
   const watchContractCmd = new WatchContractCmd();
-  await watchContractCmd.init(Database, Indexer);
+  await watchContractCmd.init(Database);
+  await watchContractCmd.initIndexer(Indexer);
 
   await watchContractCmd.exec();
 };

--- a/packages/uni-watcher/src/fill.ts
+++ b/packages/uni-watcher/src/fill.ts
@@ -15,7 +15,8 @@ const log = debug('vulcanize:server');
 
 export const main = async (): Promise<any> => {
   const fillCmd = new FillCmd();
-  await fillCmd.init(Database, Indexer, EventWatcher);
+  await fillCmd.init(Database);
+  await fillCmd.initIndexer(Indexer, EventWatcher);
 
   await fillCmd.exec();
 };

--- a/packages/uni-watcher/src/job-runner.ts
+++ b/packages/uni-watcher/src/job-runner.ts
@@ -19,7 +19,8 @@ export const main = async (): Promise<any> => {
   const jobRunnerCmd = new JobRunnerCmd();
 
   const config: Config = await jobRunnerCmd.initConfig();
-  await jobRunnerCmd.init(Database, Indexer);
+  await jobRunnerCmd.init(Database);
+  await jobRunnerCmd.initIndexer(Indexer);
 
   const jobQueue = jobRunnerCmd.jobQueue;
   const indexer = jobRunnerCmd.indexer as Indexer;

--- a/packages/uni-watcher/src/server.ts
+++ b/packages/uni-watcher/src/server.ts
@@ -17,7 +17,8 @@ const log = debug('vulcanize:server');
 
 export const main = async (): Promise<any> => {
   const serverCmd = new ServerCmd();
-  await serverCmd.init(Database, Indexer, EventWatcher);
+  await serverCmd.init(Database);
+  await serverCmd.initIndexer(Indexer, EventWatcher);
 
   return serverCmd.exec(createResolvers, typeDefs);
 };


### PR DESCRIPTION
Part of https://github.com/vulcanize/uniswap-watcher-ts/issues/360
Requires https://github.com/cerc-io/watcher-ts/pull/259

- Import graph database from util package instead of graph-node
- Refactor CLIs after removing graph-node dependency in cli package