### PR TITLE
Changes for sushiswap watchers

### DIFF
--- a/packages/erc20-watcher/environments/local.toml
+++ b/packages/erc20-watcher/environments/local.toml
@@ -25,6 +25,7 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
+    rpcClient = true
 
   [upstream.cache]
     name = "requests"

--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -10,7 +10,6 @@ import JSONbig from 'json-bigint';
 import { ethers } from 'ethers';
 
 import { IndexerInterface } from '@vulcanize/util';
-import { EthClient } from '@cerc-io/ipld-eth-client';
 import {
   Indexer as BaseIndexer,
   ServerConfig,
@@ -22,7 +21,8 @@ import {
   JobQueue,
   DatabaseInterface,
   Clients,
-  StateKind
+  StateKind,
+  EthClient
 } from '@cerc-io/util';
 import { StorageLayout, MappingKey } from '@cerc-io/solidity-mapper';
 

--- a/packages/erc20-watcher/src/indexer.ts
+++ b/packages/erc20-watcher/src/indexer.ts
@@ -139,9 +139,11 @@ export class Indexer implements IndexerInterface {
 
   async totalSupply (blockHash: string, token: string): Promise<ValueResult> {
     let result: ValueResult;
+    const { block: { number: blockNumber } } = await this._ethClient.getBlockByHash(blockHash);
 
     if (this._serverMode === ETH_CALL_MODE) {
-      const value = await fetchTokenTotalSupply(this._ethProvider, blockHash, token);
+      // eth_call doesnt support calling method by blockHash https://eth.wiki/json-rpc/API#the-default-block-parameter
+      const value = await fetchTokenTotalSupply(this._ethProvider, blockNumber, token);
 
       result = { value };
     } else {
@@ -174,7 +176,7 @@ export class Indexer implements IndexerInterface {
       const contract = new ethers.Contract(token, this._abi, this._ethProvider);
 
       // eth_call doesnt support calling method by blockHash https://eth.wiki/json-rpc/API#the-default-block-parameter
-      const value = await contract.balanceOf(owner, { blockTag: blockHash });
+      const value = await contract.balanceOf(owner, { blockTag: blockNumber });
 
       result = {
         value: BigInt(value.toString())
@@ -209,7 +211,8 @@ export class Indexer implements IndexerInterface {
 
     if (this._serverMode === ETH_CALL_MODE) {
       const contract = new ethers.Contract(token, this._abi, this._ethProvider);
-      const value = await contract.allowance(owner, spender, { blockTag: blockHash });
+      // eth_call doesnt support calling method by blockHash https://eth.wiki/json-rpc/API#the-default-block-parameter
+      const value = await contract.allowance(owner, spender, { blockTag: blockNumber });
 
       result = {
         value: BigInt(value.toString())
@@ -243,7 +246,8 @@ export class Indexer implements IndexerInterface {
     const { block: { number: blockNumber } } = await this._ethClient.getBlockByHash(blockHash);
 
     if (this._serverMode === ETH_CALL_MODE) {
-      const value = await fetchTokenName(this._ethProvider, blockHash, token);
+      // eth_call doesnt support calling method by blockHash https://eth.wiki/json-rpc/API#the-default-block-parameter
+      const value = await fetchTokenName(this._ethProvider, blockNumber, token);
 
       result = { value };
     } else {
@@ -272,7 +276,8 @@ export class Indexer implements IndexerInterface {
     const { block: { number: blockNumber } } = await this._ethClient.getBlockByHash(blockHash);
 
     if (this._serverMode === ETH_CALL_MODE) {
-      const value = await fetchTokenSymbol(this._ethProvider, blockHash, token);
+      // eth_call doesnt support calling method by blockHash https://eth.wiki/json-rpc/API#the-default-block-parameter
+      const value = await fetchTokenSymbol(this._ethProvider, blockNumber, token);
 
       result = { value };
     } else {
@@ -301,7 +306,8 @@ export class Indexer implements IndexerInterface {
     const { block: { number: blockNumber } } = await this._ethClient.getBlockByHash(blockHash);
 
     if (this._serverMode === ETH_CALL_MODE) {
-      const value = await fetchTokenDecimals(this._ethProvider, blockHash, token);
+      // eth_call doesnt support calling method by blockHash https://eth.wiki/json-rpc/API#the-default-block-parameter
+      const value = await fetchTokenDecimals(this._ethProvider, blockNumber, token);
 
       result = { value };
     } else {

--- a/packages/erc20-watcher/src/utils/index.ts
+++ b/packages/erc20-watcher/src/utils/index.ts
@@ -9,18 +9,18 @@ import ERC20SymbolBytesABI from '../artifacts/ERC20SymbolBytes.json';
 import ERC20NameBytesABI from '../artifacts/ERC20NameBytes.json';
 import { StaticTokenDefinition } from './static-token-definition';
 
-export const fetchTokenSymbol = async (ethProvider: providers.BaseProvider, blockHash: string, tokenAddress: string): Promise<string> => {
+export const fetchTokenSymbol = async (ethProvider: providers.BaseProvider, blockNumber: number, tokenAddress: string): Promise<string> => {
   const contract = new Contract(tokenAddress, abi, ethProvider);
   const contractSymbolBytes = new Contract(tokenAddress, ERC20SymbolBytesABI, ethProvider);
   let symbolValue = 'unknown';
 
   // Try types string and bytes32 for symbol.
   try {
-    const result = await contract.symbol({ blockTag: blockHash });
+    const result = await contract.symbol({ blockTag: blockNumber });
     symbolValue = result;
   } catch (error) {
     try {
-      const result = await contractSymbolBytes.symbol({ blockTag: blockHash });
+      const result = await contractSymbolBytes.symbol({ blockTag: blockNumber });
 
       // For broken pairs that have no symbol function exposed.
       if (!isNullEthValue(utils.hexlify(result))) {
@@ -41,18 +41,18 @@ export const fetchTokenSymbol = async (ethProvider: providers.BaseProvider, bloc
   return symbolValue;
 };
 
-export const fetchTokenName = async (ethProvider: providers.BaseProvider, blockHash: string, tokenAddress: string): Promise<string> => {
+export const fetchTokenName = async (ethProvider: providers.BaseProvider, blockNumber: number, tokenAddress: string): Promise<string> => {
   const contract = new Contract(tokenAddress, abi, ethProvider);
   const contractNameBytes = new Contract(tokenAddress, ERC20NameBytesABI, ethProvider);
   let nameValue = 'unknown';
 
   // Try types string and bytes32 for name.
   try {
-    const result = await contract.name({ blockTag: blockHash });
+    const result = await contract.name({ blockTag: blockNumber });
     nameValue = result;
   } catch (error) {
     try {
-      const result = await contractNameBytes.name({ blockTag: blockHash });
+      const result = await contractNameBytes.name({ blockTag: blockNumber });
 
       // For broken pairs that have no name function exposed.
       if (!isNullEthValue(utils.hexlify(result))) {
@@ -73,12 +73,12 @@ export const fetchTokenName = async (ethProvider: providers.BaseProvider, blockH
   return nameValue;
 };
 
-export const fetchTokenTotalSupply = async (ethProvider: providers.BaseProvider, blockHash: string, tokenAddress: string): Promise<bigint> => {
+export const fetchTokenTotalSupply = async (ethProvider: providers.BaseProvider, blockNumber: number, tokenAddress: string): Promise<bigint> => {
   const contract = new Contract(tokenAddress, abi, ethProvider);
   let totalSupplyValue = null;
 
   try {
-    const result = await contract.totalSupply({ blockTag: blockHash });
+    const result = await contract.totalSupply({ blockTag: blockNumber });
     totalSupplyValue = result.toString();
   } catch (error) {
     totalSupplyValue = 0;
@@ -87,14 +87,14 @@ export const fetchTokenTotalSupply = async (ethProvider: providers.BaseProvider,
   return BigInt(totalSupplyValue);
 };
 
-export const fetchTokenDecimals = async (ethProvider: providers.BaseProvider, blockHash: string, tokenAddress: string): Promise<bigint> => {
+export const fetchTokenDecimals = async (ethProvider: providers.BaseProvider, blockNumber: number, tokenAddress: string): Promise<bigint> => {
   const contract = new Contract(tokenAddress, abi, ethProvider);
 
   // Try types uint8 for decimals.
   let decimalValue = null;
 
   try {
-    const result = await contract.decimals({ blockTag: blockHash });
+    const result = await contract.decimals({ blockTag: blockNumber });
     decimalValue = result.toString();
   } catch (error) {
     // Try with the static definition.

--- a/packages/uni-info-watcher/environments/local.toml
+++ b/packages/uni-info-watcher/environments/local.toml
@@ -67,6 +67,7 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
+    rpcClient = true
 
   [upstream.cache]
     name = "requests"

--- a/packages/uni-info-watcher/environments/test.toml
+++ b/packages/uni-info-watcher/environments/test.toml
@@ -20,6 +20,7 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8545"
+    rpcClient = true
 
   [upstream.cache]
     name = "requests"

--- a/packages/uni-info-watcher/package.json
+++ b/packages/uni-info-watcher/package.json
@@ -36,7 +36,7 @@
     "job-runner": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true node --enable-source-maps dist/job-runner.js",
     "job-runner:prof": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true node --require pprof --enable-source-maps dist/job-runner.js",
     "job-runner:dev": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true ts-node src/job-runner.ts",
-    "smoke-test": "yarn test:init && mocha src/smoke.test.ts",
+    "smoke-test": "mocha src/smoke.test.ts",
     "fill": "DEBUG=vulcanize:* node --enable-source-maps dist/fill.js",
     "fill:prof": "DEBUG=vulcanize:* node --require pprof --enable-source-maps dist/fill.js",
     "fill:dev": "DEBUG=vulcanize:* ts-node src/fill.ts",

--- a/packages/uni-info-watcher/src/entity/BlockProgress.ts
+++ b/packages/uni-info-watcher/src/entity/BlockProgress.ts
@@ -16,7 +16,7 @@ export class BlockProgress implements BlockProgressInterface {
   @PrimaryGeneratedColumn()
     id!: number;
 
-  @Column('varchar')
+  @Column('varchar', { nullable: true })
     cid!: string;
 
   @Column('varchar', { length: 66 })

--- a/packages/uni-info-watcher/src/indexer.ts
+++ b/packages/uni-info-watcher/src/indexer.ts
@@ -30,9 +30,9 @@ import {
   DatabaseInterface,
   Clients,
   updateSubgraphState,
-  dumpSubgraphState
+  dumpSubgraphState,
+  EthClient
 } from '@cerc-io/util';
-import { EthClient } from '@cerc-io/ipld-eth-client';
 import { StorageLayout, MappingKey } from '@cerc-io/solidity-mapper';
 
 import { findEthPerToken, getEthPriceInUSD, getTrackedAmountUSD, sqrtPriceX96ToTokenPrices, WHITELIST_TOKENS } from './utils/pricing';

--- a/packages/uni-info-watcher/src/smoke.test.ts
+++ b/packages/uni-info-watcher/src/smoke.test.ts
@@ -613,8 +613,8 @@ describe('uni-info-watcher', () => {
       ]);
       eventValue = values[1];
 
-      // Sleeping for 5 sec for the event to be processed.
-      await wait(5000);
+      // Sleeping for 10 sec for the event to be processed.
+      await wait(10000);
     });
 
     it('should update Token entities', async () => {

--- a/packages/uni-info-watcher/test/init.ts
+++ b/packages/uni-info-watcher/test/init.ts
@@ -4,7 +4,8 @@
 
 import assert from 'assert';
 
-import { JobQueue, getConfig, initClients } from '@cerc-io/util';
+import { JobQueue, getConfig } from '@cerc-io/util';
+import { initClients } from '@cerc-io/cli';
 import { Config } from '@vulcanize/util';
 import { Client as ERC20Client } from '@vulcanize/erc20-watcher';
 import { Client as UniClient } from '@vulcanize/uni-watcher';

--- a/packages/uni-watcher/environments/local.toml
+++ b/packages/uni-watcher/environments/local.toml
@@ -24,6 +24,7 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8081"
+    rpcClient = true
 
   [upstream.cache]
     name = "requests"

--- a/packages/uni-watcher/environments/test.toml
+++ b/packages/uni-watcher/environments/test.toml
@@ -17,6 +17,7 @@
   [upstream.ethServer]
     gqlApiEndpoint = "http://127.0.0.1:8082/graphql"
     rpcProviderEndpoint = "http://127.0.0.1:8545"
+    rpcClient = true
 
   [upstream.cache]
     name = "requests"

--- a/packages/uni-watcher/package.json
+++ b/packages/uni-watcher/package.json
@@ -16,7 +16,7 @@
     "job-runner": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true node --enable-source-maps dist/job-runner.js",
     "job-runner:prof": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true node --require pprof --enable-source-maps dist/job-runner.js",
     "job-runner:dev": "DEBUG=vulcanize:* YARN_CHILD_PROCESS=true ts-node src/job-runner.ts",
-    "smoke-test": "yarn test:init && mocha src/smoke.test.ts",
+    "smoke-test": "mocha src/smoke.test.ts",
     "fill": "DEBUG=vulcanize:* node --enable-source-maps dist/fill.js",
     "fill:prof": "DEBUG=vulcanize:* node --require pprof --enable-source-maps dist/fill.js",
     "fill:dev": "DEBUG=vulcanize:* ts-node src/fill.ts",

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -21,9 +21,9 @@ import {
   JobQueue,
   DatabaseInterface,
   Clients,
-  StateKind
+  StateKind,
+  EthClient
 } from '@cerc-io/util';
-import { EthClient } from '@cerc-io/ipld-eth-client';
 import { StorageLayout, MappingKey } from '@cerc-io/solidity-mapper';
 
 import { Database } from './database';

--- a/packages/uni-watcher/src/indexer.ts
+++ b/packages/uni-watcher/src/indexer.ts
@@ -398,9 +398,11 @@ export class Indexer implements IndexerInterface {
 
   async callGetPool (blockHash: string, contractAddress: string, key0: string, key1: string, key2: number): Promise<ValueResult> {
     const contract = new ethers.Contract(contractAddress, factoryABI, this._ethProvider);
+    const block = await this.getBlockProgress(blockHash);
+    const blockNumber = block?.blockNumber;
 
     try {
-      const value = await contract.getPool(key0, key1, key2, { blockTag: blockHash });
+      const value = await contract.getPool(key0, key1, key2, { blockTag: blockNumber });
 
       return { value };
     } catch (error: any) {
@@ -417,9 +419,11 @@ export class Indexer implements IndexerInterface {
 
   async positions (blockHash: string, contractAddress: string, tokenId: string): Promise<ValueResult> {
     const contract = new ethers.Contract(contractAddress, nfpmABI, this._ethProvider);
+    const block = await this.getBlockProgress(blockHash);
+    const blockNumber = block?.blockNumber;
 
     try {
-      const value = await contract.positions(tokenId, { blockTag: blockHash });
+      const value = await contract.positions(tokenId, { blockTag: blockNumber });
 
       return { value };
     } catch (error: any) {
@@ -436,9 +440,11 @@ export class Indexer implements IndexerInterface {
 
   async ticks (blockHash: string, contractAddress: string, tick: number): Promise<ValueResult> {
     const contract = new ethers.Contract(contractAddress, poolABI, this._ethProvider);
+    const block = await this.getBlockProgress(blockHash);
+    const blockNumber = block?.blockNumber;
 
     try {
-      const value = await contract.ticks(tick, { blockTag: blockHash });
+      const value = await contract.ticks(tick, { blockTag: blockNumber });
 
       return { value };
     } catch (error: any) {
@@ -455,9 +461,11 @@ export class Indexer implements IndexerInterface {
 
   async feeGrowthGlobal0X128 (blockHash: string, contractAddress: string): Promise<ValueResult> {
     const contract = new ethers.Contract(contractAddress, poolABI, this._ethProvider);
+    const block = await this.getBlockProgress(blockHash);
+    const blockNumber = block?.blockNumber;
 
     try {
-      const value = await contract.feeGrowthGlobal0X128({ blockTag: blockHash });
+      const value = await contract.feeGrowthGlobal0X128({ blockTag: blockNumber });
 
       return { value };
     } catch (error: any) {
@@ -474,9 +482,11 @@ export class Indexer implements IndexerInterface {
 
   async feeGrowthGlobal1X128 (blockHash: string, contractAddress: string): Promise<ValueResult> {
     const contract = new ethers.Contract(contractAddress, poolABI, this._ethProvider);
+    const block = await this.getBlockProgress(blockHash);
+    const blockNumber = block?.blockNumber;
 
     try {
-      const value = await contract.feeGrowthGlobal1X128({ blockTag: blockHash });
+      const value = await contract.feeGrowthGlobal1X128({ blockTag: blockNumber });
 
       return { value };
     } catch (error: any) {

--- a/packages/uni-watcher/src/smoke.test.ts
+++ b/packages/uni-watcher/src/smoke.test.ts
@@ -19,7 +19,7 @@ import {
   NFPM_ABI
 } from '@vulcanize/util/test';
 import { getCache } from '@cerc-io/cache';
-import { EthClient } from '@cerc-io/ipld-eth-client';
+import { EthClient } from '@cerc-io/rpc-eth-client';
 import {
   abi as FACTORY_ABI
 } from '@uniswap/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json';
@@ -76,8 +76,7 @@ describe('uni-watcher', () => {
     assert(host, 'Missing host.');
     assert(port, 'Missing port.');
 
-    const { ethServer: { gqlApiEndpoint, rpcProviderEndpoint }, cache: cacheConfig } = upstream;
-    assert(gqlApiEndpoint, 'Missing upstream ethServer.gqlApiEndpoint.');
+    const { ethServer: { rpcProviderEndpoint }, cache: cacheConfig } = upstream;
     assert(rpcProviderEndpoint, 'Missing upstream ethServer.rpcProviderEndpoint.');
     assert(cacheConfig, 'Missing dbConfig.');
 
@@ -86,7 +85,7 @@ describe('uni-watcher', () => {
 
     const cache = await getCache(cacheConfig);
     ethClient = new EthClient({
-      gqlEndpoint: gqlApiEndpoint,
+      rpcEndpoint: rpcProviderEndpoint,
       cache
     });
 

--- a/packages/uni-watcher/test/init.ts
+++ b/packages/uni-watcher/test/init.ts
@@ -5,7 +5,8 @@
 import { Contract, ethers, Signer } from 'ethers';
 import assert from 'assert';
 
-import { JobQueue, getConfig, initClients } from '@cerc-io/util';
+import { JobQueue, getConfig } from '@cerc-io/util';
+import { initClients } from '@cerc-io/cli';
 import { Config } from '@vulcanize/util';
 import {
   deployWETH9Token,

--- a/packages/util/src/job-runner.ts
+++ b/packages/util/src/job-runner.ts
@@ -5,6 +5,7 @@
 import assert from 'assert';
 import debug from 'debug';
 import { DeepPartial, In } from 'typeorm';
+import { ethers } from 'ethers';
 
 import {
   JobQueueConfig,
@@ -183,27 +184,29 @@ export class JobRunner {
       // Check how many branches there are at the given height/block number.
       const blocksAtHeight = await this._indexer.getBlocksAtHeight(pruneBlockHeight, false);
 
-      // Should be at least 1.
-      assert(blocksAtHeight.length);
+      let newCanonicalBlockHash = ethers.constants.HashZero;
 
-      let newCanonicalBlockHash;
-      // We have more than one node at this height, so prune all nodes not reachable from indexed block at max reorg depth from prune height.
-      // This will lead to orphaned nodes, which will get pruned at the next height.
-      if (blocksAtHeight.length > 1) {
-        const [indexedBlock] = await this._indexer.getBlocksAtHeight(pruneBlockHeight + MAX_REORG_DEPTH, false);
+      // Prune only if blocks exist at pruneBlockHeight
+      // There might be missing null block in FEVM; Only update sync status if so
+      if (blocksAtHeight.length !== 0) {
+        // We have more than one node at this height, so prune all nodes not reachable from indexed block at max reorg depth from prune height.
+        // This will lead to orphaned nodes, which will get pruned at the next height.
+        if (blocksAtHeight.length > 1) {
+          const [indexedBlock] = await this._indexer.getBlocksAtHeight(pruneBlockHeight + MAX_REORG_DEPTH, false);
 
-        // Get ancestor blockHash from indexed block at prune height.
-        const ancestorBlockHash = await this._indexer.getAncestorAtDepth(indexedBlock.blockHash, MAX_REORG_DEPTH);
-        newCanonicalBlockHash = ancestorBlockHash;
+          // Get ancestor blockHash from indexed block at prune height.
+          const ancestorBlockHash = await this._indexer.getAncestorAtDepth(indexedBlock.blockHash, MAX_REORG_DEPTH);
+          newCanonicalBlockHash = ancestorBlockHash;
 
-        const blocksToBePruned = blocksAtHeight.filter(block => ancestorBlockHash !== block.blockHash);
+          const blocksToBePruned = blocksAtHeight.filter(block => ancestorBlockHash !== block.blockHash);
 
-        if (blocksToBePruned.length) {
-          // Mark blocks pruned which are not the ancestor block.
-          await this._indexer.markBlocksAsPruned(blocksToBePruned);
+          if (blocksToBePruned.length) {
+            // Mark blocks pruned which are not the ancestor block.
+            await this._indexer.markBlocksAsPruned(blocksToBePruned);
+          }
+        } else {
+          newCanonicalBlockHash = blocksAtHeight[0].blockHash;
         }
-      } else {
-        newCanonicalBlockHash = blocksAtHeight[0].blockHash;
       }
 
       // Update the canonical block in the SyncStatus.

--- a/packages/util/test/actions.ts
+++ b/packages/util/test/actions.ts
@@ -33,7 +33,7 @@ import {
   bytecode as WETH9_BYTECODE
 } from '../artifacts/test/contracts/WETH9.sol/WETH9.json';
 
-export { NFPM_ABI, TESTERC20_ABI };
+export { NFPM_ABI, TESTERC20_ABI, TESTUNISWAPV3CALLEE_ABI };
 export const TICK_MIN = -887272;
 export const TICK_MAX = 887272;
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/399

- Update imports from watcher-ts packages
- Make cid nullable in uni-info-watcher similar to uni-watcher
- Update smoke tests to use deployed contracts
- Use blockNumber for eth calls in uni-watcher
- Handle pruning of missing null blocks in FEVM